### PR TITLE
MINOR: config: Option --transparent can be set via configuration file

### DIFF
--- a/basic.cfg
+++ b/basic.cfg
@@ -5,6 +5,7 @@ verbose: false;
 foreground: false;
 inetd: false;
 numeric: false;
+transparent: false;
 timeout: 2;
 user: "nobody";
 pidfile: "/var/run/sslh.pid";

--- a/example.cfg
+++ b/example.cfg
@@ -7,6 +7,7 @@ verbose: true;
 foreground: true;
 inetd: false;
 numeric: false;
+transparent: false;
 timeout: 2;
 user: "nobody";
 pidfile: "/var/run/sslh.pid";

--- a/sslh-main.c
+++ b/sslh-main.c
@@ -270,6 +270,7 @@ static int config_parse(char *filename, struct addrinfo **listen, struct proto *
     config_lookup_bool(&config, "inetd", &inetd);
     config_lookup_bool(&config, "foreground", &foreground);
     config_lookup_bool(&config, "numeric", &numeric);
+    config_lookup_bool(&config, "transparent", &transparent);
 
     if (config_lookup_int(&config, "timeout", &timeout) == CONFIG_TRUE) {
         probing_timeout = timeout;


### PR DESCRIPTION
This patch allows to set option --transparent in an SSLH configuration
file. Without it, transparent mode is only possible by passing the
option on the command line.
