### PR TITLE
Implement libcap support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 VERSION=$(shell ./genver.sh -r)
 USELIBCONFIG=1	# Use libconfig? (necessary to use configuration files)
 USELIBWRAP=	# Use libwrap?
+USELIBCAP=	# Use libcap?
 COV_TEST= 	# Perform test coverage?
 PREFIX=/usr/local
 
@@ -29,6 +30,11 @@ endif
 ifneq ($(strip $(USELIBCONFIG)),)
 	LIBS:=$(LIBS) -lconfig
 	CPPFLAGS+=-DLIBCONFIG
+endif
+
+ifneq ($(strip $(USELIBCAP)),)
+	LIBS:=$(LIBS) -lcap
+	CPPFLAGS+=-DLIBCAP
 endif
 
 all: sslh $(MAN) echosrv

--- a/README
+++ b/README
@@ -157,16 +157,21 @@ in inetd mode.
 sslh options: -i for inetd mode, --http to forward http
 connexions to port 80, and SSH connexions to port 22.
 
-==== capapbilities support ====
+==== capabilities support ====
 
-On Linux (only?), you can use POSIX capabilities to reduce a
-server's capabilities to the minimum it needs (see
-capabilities(8).  For sslh, this is CAP_NET_ADMIN (to
-perform transparent proxy-ing) and CAP_NET_BIND_SERVICE (to
-bind to port 443 without being root).
+On Linux (only?), you can compile sslh with USELIBCAP=1 to
+make use of POSIX capabilities; this will save the required
+capabilities needed for transparent proxying for unprivileged
+processes.
 
-The simplest way to use capabilities is to give them to the
-executable as root:
+Alternatively, you may use filesystem capabilities instead
+of starting sslh as root and asking it to drop privileges.
+You will need CAP_NET_BIND_SERVICE for listening on port 443
+and CAP_NET_ADMIN for transparent proxying (see
+capabilities(7)).
+
+You can use the setcap(8) utility to give these capabilities
+to the executable:
 
 # setcap cap_net_bind_service,cap_net_admin+pe sslh-select
 
@@ -174,13 +179,9 @@ Then you can run sslh-select as an unpriviledged user, e.g.:
 
 $ sslh-select -p myname:443 --ssh localhost:22 --ssl localhost:443
 
-This has 2 advantages over starting as root with -u:
-- You no longer start as root (duh)
-- This enables transparent proxying.
-
 Caveat: CAP_NET_ADMIN does give sslh too many rights, e.g.
 configuring the interface. If you're not going to use
-transparent proxying, just don't use it.
+transparent proxying, just don't use it (or use the libcap method).
 
 ==== Transparent proxy support ====
 
@@ -192,8 +193,8 @@ simplifies IP-based access control (or makes it possible at
 all).
 
 sslh needs extended rights to perform this: you'll need to
-give it cap_net_admin capabilities (see appropriate chapter)
-or run it as root (but don't do that).
+give it cap_net_admin capabilities manually or enable libcap
+support (see appropriate chapter).
 
 The firewalling tables also need to be adjusted as follow
 (example to connect to https on 4443 -- adapt to your needs


### PR DESCRIPTION
Use libcap for saving CAP_NET_ADMIN (if --transparent is given) over a
setuid(). We don’t need CAP_NET_BIND_SERVICE as the listening sockets
are established before dropping root.
