### PR TITLE
sslh-fork: close all listening sockets in shoveler

### DIFF
--- a/sslh-fork.c
+++ b/sslh-fork.c
@@ -157,7 +157,8 @@ void main_loop(int listen_sockets[], int num_addr_listen)
 
                 if (!fork())
                 {
-                    close(listen_sockets[i]);
+                    for (i = 0; i < num_addr_listen; ++i)
+                        close(listen_sockets[i]);
                     start_shoveler(in_socket);
                     exit(0);
                 }


### PR DESCRIPTION
When we're watching multiple sockets, we don't want to just close
the active one we got a connection on before launching the shoveler.
If we want to restart the daemon, we run into problems because the
socket is still in use.  Instead, close all the sockets we were
listening on.

Signed-off-by: Mike Frysinger vapier@gentoo.org
