### PR TITLE
Fixed possible file descriptor leak.

### DIFF
--- a/common.c
+++ b/common.c
@@ -155,6 +155,7 @@ int connect_addr(struct connection *cnx, int fd_from)
             if (res == -1) {
                 log_message(LOG_ERR, "forward to %s failed:connect: %s\n", 
                             cnx->proto->description, strerror(errno));
+                close(fd);
             } else {
                 return fd;
             }


### PR DESCRIPTION
This is a fix for a possible file descriptor leak problem that can lead to excess maximum number of open file descriptors.
This problem can be easely reproduced on Mac OS X where default maximum number of open file descriptor is 256.
