### PR TITLE
Use portable way of getting modified time

### DIFF
--- a/genver.sh
+++ b/genver.sh
@@ -21,7 +21,7 @@ if ! `(git status | grep -q "On branch") 2> /dev/null`; then
             # zip file with all files dated from the last
             # change: use the Makefile's modification time as a
             # release number
-            release=head-`stat -c "%y" Makefile | sed 's/ .*//'`
+            release=head-`perl -MPOSIX -e 'print strftime "%Y-%m-%d",localtime((stat "Makefile")[9])'`
         fi
 fi
 


### PR DESCRIPTION
sslh 1.16 compiles fine on OS X. There's just one little issue: `stat -c` is GNU-only, so the version detection fails; this results in a reported version of "zip-".

This is not my area of expertise, but I grabbed a more portable equivalent of `stat -c "%y"` from the following link, and it works as expected for me.
http://ginini.com/techblog/displaying-the-modification-date-of-a-file/

Maybe there's an even better solution?
