### PR TITLE
Build fails in CentOS6 - this fixes it

### DIFF
--- a/sslh-main.c
+++ b/sslh-main.c
@@ -280,7 +280,10 @@ static int config_parse(char *filename, struct addrinfo **listen, struct proto *
 
     config_init(&config);
     if (config_read_file(&config, filename) == CONFIG_FALSE) {
-        if (config_error_type(&config) == CONFIG_ERR_PARSE) {
+/* If it's a parse error then there will be a line number for the failure
+ * an I/O error (such as non-existent file) will have the error line as 0
+ */
+        if (config_error_line(&config) != 0) {
             fprintf(stderr, "%s:%d:%s\n", 
                     filename,
                     config_error_line(&config),


### PR DESCRIPTION
CentOS6 only has libconfig 1.3.2 and not 1.4+

In the parse_config function config_error_t is being checked to see if it is CONFIG_ERR_PARSE but this enum was only added in 1.4+

By checking the line number of the error instead we can have the same behaviour but still allow this to build in C6. If the line number is 0 then the file failed to be read for some reason (not found, permissions, etc). If the line number is anything but 0 then we know it's a parse error and exit rather than return and let the user know the line number that failed.