### PR TITLE
probe: remove non-POSIX REG_STARTEND REGEX

### DIFF
--- a/probe.c
+++ b/probe.c
@@ -247,7 +247,7 @@ static int regex_probe(const char *p, int len, struct proto *proto)
     regex_t **probe = proto->data;
     regmatch_t pos = { 0, len };
 
-    for (; *probe && regexec(*probe, p, 0, &pos, REG_STARTEND); probe++)
+    for (; *probe && regexec(*probe, p, 0, &pos, 0); probe++)
         /* try them all */;
 
     return (*probe != NULL);


### PR DESCRIPTION
REG_STARTEND is not required as the regmatch_t struct being passed to
regexec() hardcodes rm_so as 0.

This issue was uncovered because OpenWrt recently moved away from uClibc
to musl.

Closes: #40

Signed-off-by: Jonathan McCrohan <jmccrohan@gmail.com>