### PR TITLE
Enable PCRE as RegEx Library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 # Configuration
 
 VERSION=$(shell ./genver.sh -r)
+ENABLE_REGEX=1  # Enable regex probes
 USELIBCONFIG=1	# Use libconfig? (necessary to use configuration files)
-USELIBPCRE=1	# Use libpcre? (necessary to use regex probe)
+USELIBPCRE=1	# Use libpcre? (needed for regex on musl)
 USELIBWRAP?=	# Use libwrap?
 USELIBCAP=	# Use libcap?
 COV_TEST= 	# Perform test coverage?
@@ -30,8 +31,13 @@ ifneq ($(strip $(USELIBWRAP)),)
 	CPPFLAGS+=-DLIBWRAP
 endif
 
+ifneq ($(strip $(ENABLE_REGEX)),)
+	CPPFLAGS+=-DENABLE_REGEX
+endif
+
 ifneq ($(strip $(USELIBPCRE)),)
 	CPPFLAGS+=-DLIBPCRE
+	LIBS:=$(LIBS) -lpcre
 endif
 
 ifneq ($(strip $(USELIBCONFIG)),)

--- a/probe.c
+++ b/probe.c
@@ -21,8 +21,12 @@
 
 #define _GNU_SOURCE
 #include <stdio.h>
+#ifdef ENABLE_REGEX
 #ifdef LIBPCRE
+#include <pcreposix.h>
+#else
 #include <regex.h>
+#endif
 #endif
 #include <ctype.h>
 #include "probe.h"
@@ -275,7 +279,7 @@ static int is_adb_protocol(const char *p, int len, struct proto *proto)
 
 static int regex_probe(const char *p, int len, struct proto *proto)
 {
-#ifdef LIBPCRE
+#ifdef ENABLE_REGEX
     regex_t **probe = proto->data;
     regmatch_t pos = { 0, len };
 

--- a/sslh-main.c
+++ b/sslh-main.c
@@ -25,8 +25,12 @@
 #ifdef LIBCONFIG
 #include <libconfig.h>
 #endif
+#ifdef ENABLE_REGEX
 #ifdef LIBPCRE
+#include <pcreposix.h>
+#else
 #include <regex.h>
+#endif
 #endif
 
 #include "common.h"
@@ -176,7 +180,7 @@ static int config_listen(config_t *config, struct addrinfo **listen)
 #ifdef LIBCONFIG
 static void setup_regex_probe(struct proto *p, config_setting_t* probes)
 {
-#ifdef LIBPCRE
+#ifdef ENABLE_REGEX
     int num_probes, errsize, i, res;
     char *err;
     const char * expr;


### PR DESCRIPTION
This ought to address issue #40 -

This enables using PCRE for regular expressions. This allows folks with the musl libc to still use regex, people on glibc can use either.