### PR TITLE
Fix daemon start syntax

### DIFF
--- a/scripts/etc.init.d.sslh
+++ b/scripts/etc.init.d.sslh
@@ -27,7 +27,7 @@ DAEMON=$PREFIX/sbin/sslh
 start()
 {
         echo "Start services: sslh"
-        $DAEMON -F /etc/sslh.cfg
+        $DAEMON -F/etc/sslh.cfg
         logger -t ${tag} -p ${facility} -i 'Started sslh'
 }
 


### PR DESCRIPTION
Per the changelog for 1.17: argument to -F can no longer be separated from the option by a space, e.g. must be -Ffoo.cfg).  This fixes the `/etc/sslh/sslh.cfg:file I/O error` message if the config file is stored in `/etc/sslh.cfg` as given by Readme.md.