### PR TITLE
Add ALPN protocol based probe

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@ vNEXT:
 	Added USELIBPCRE to make use of regex engine
 	optional.
 
-	Added support for RFC4366 SNI 
+	Added support for RFC4366 SNI and RFC7301 ALPN
 	(Travis Burtrum)
 
 	Changed connection log to include the name of the probe that
@@ -10,8 +10,8 @@ vNEXT:
 
 	Changed configuration file format: 'probe' field is
 	no longer required, 'name' field can now contain
-	'sni' or 'regex', with corresponding options (see
-	example.org)
+	'tls' or 'regex', with corresponding options (see
+	example.cfg)
 	Added 'log_level' option to each protocol, which
 	allows to turn off generation of log at each
 	connection.

--- a/example.cfg
+++ b/example.cfg
@@ -24,14 +24,19 @@ listen:
 #
 # Each protocol entry consists of:
 #   name: name of the probe. These are listed on the command
-#   line (ssh -?), plus 'regex', 'sni' and 'timeout'.
+#   line (ssh -?), plus 'regex' and 'timeout'.
 
 #   service: (optional) libwrap service name (see hosts_access(5))
 #   host, port: where to connect when this probe succeeds
 #
 #  Probe-specific options:
-#       sni: 
-#               sni_hotnames: list of FQDN for that target
+#       tls:
+#               sni_hostnames:  list of FQDN for that target
+#               alpn_protocols: list of ALPN protocols for that target, see:
+#               https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
+#
+#               if both sni_hostnames AND alpn_protocols are specified, both must match
+#               if neither are set, it is just checked whether this is the TLS protocol or not
 #       regex:
 #               regex_patterns: list of patterns to match for
 #               that target.
@@ -39,15 +44,26 @@ listen:
 # sslh will try each probe in order they are declared, and
 # connect to the first that matches.
 #
-# You can specify several of 'regex' and 'sni'.
+# You can specify several of 'regex' and 'tls'.
  
 protocols:
 (
      { name: "ssh"; service: "ssh"; host: "localhost"; port: "22"; },
      { name: "http"; host: "localhost"; port: "80"; },
 
-     { name: "sni"; host: "localhost"; port: "993"; sni_hostnames: [ "mail.rutschle.net", "mail.englishintoulouse.com" ]; log_level: 0; },
-     { name: "sni"; host: "localhost"; port: "xmpp-client"; sni_hostnames: [ "im.rutschle.net", "im.englishintoulouse.com" ];  log_level: 0;},
+# match BOTH ALPN/SNI
+     { name: "tls"; host: "localhost"; port: "5223"; alpn_protocols: [ "xmpp-client" ]; sni_hostnames: [ "im.somethingelse.net" ]; log_level: 0;},
+
+# just match ALPN
+     { name: "tls"; host: "localhost"; port: "443"; alpn_protocols: [ "h2", "http/1.1", "spdy/1", "spdy/2", "spdy/3" ]; log_level: 0; },
+     { name: "tls"; host: "localhost"; port: "xmpp-client"; alpn_protocols: [ "xmpp-client" ];  log_level: 0;},
+
+# just match SNI
+     { name: "tls"; host: "localhost"; port: "993"; sni_hostnames: [ "mail.rutschle.net", "mail.englishintoulouse.com" ]; log_level: 0; },
+     { name: "tls"; host: "localhost"; port: "xmpp-client"; sni_hostnames: [ "im.rutschle.net", "im.englishintoulouse.com" ];  log_level: 0;},
+
+# catch anything else TLS
+     { name: "tls"; host: "localhost"; port: "443"; },
 
 # OpenVPN
      { name: "regex"; host: "localhost"; port: "1194"; regex_patterns: [ "^\x00[\x0D-\xFF]$", "^\x00[\x0D-\xFF]\x38" ]; },

--- a/probe.h
+++ b/probe.h
@@ -27,7 +27,8 @@ struct proto {
     /* function to probe that protocol; parameters are buffer and length
      * containing the data to probe, and a pointer to the protocol structure */
     T_PROBE* probe;
-    void* data;     /* opaque pointer ; used to pass list of regex to regex probe, or sni hostnames to sni probe */
+    /* opaque pointer ; used to pass list of regex to regex probe, or TLSProtocol struct to sni/alpn probe */
+    void* data;
     struct proto *next; /* pointer to next protocol in list, NULL if last */
 };
 

--- a/tls.h
+++ b/tls.h
@@ -28,6 +28,11 @@
 
 #include "common.h"
 
-int parse_tls_header(const char *data, size_t data_len, char **hostname);
+struct TLSProtocol;
+
+int parse_tls_header(const struct TLSProtocol *tls_data, const char *data, size_t data_len);
+
+struct TLSProtocol *new_tls_data();
+struct TLSProtocol *tls_data_set_list(struct TLSProtocol *, int, char**);
 
 #endif


### PR DESCRIPTION
This again pulls code from [sniproxy](https://github.com/dlundquist/sniproxy/blob/alpn/src/tls.c) like the last patch, but modifies it even more, and adds support for ALPN probes.  Now tls is the name for tls/sni/alpn.  It has options sni_hostnames/alpn_protocols, if neither are set, it is just checked whether this is the TLS protocol or not, if both sni_hostnames AND alpn_protocols are specified, both must match. sniproxy isn't currently planning on supporting an AND like that, so that's one more thing sslh will have the advantage in. :)

With the new structure an SNI hostname is never malloc'd either (no malloc during probe at all, actually), so there is a speedup and safety added there.

Let me know if this needs anything else to be included!