### PR TITLE
Use CAP_NET_RAW instead of CAP_NET_ADMIN for transparent proxying.

### DIFF
--- a/common.c
+++ b/common.c
@@ -777,7 +777,7 @@ void set_capabilities(void) {
     int ncap = 0;
 
     if (cfg.transparent)
-        cap_list[ncap++] = CAP_NET_ADMIN;
+        cap_list[ncap++] = CAP_NET_RAW;
 
     caps = cap_init();
 

--- a/scripts/etc.sysconfig.sslh
+++ b/scripts/etc.sysconfig.sslh
@@ -9,7 +9,7 @@
 # is needed in order to run as sslh user
 #
 #SSLH_USER=sslh
-#setcap cap_net_bind_service,cap_net_admin=+ep $SSLH
+#setcap cap_net_bind_service,cap_net_raw=+ep $SSLH
 
 #
 # Configuration file for sslh


### PR DESCRIPTION
Available on linux since v3.2-rc1.
Introduced in the kernel in the commit https://github.com/torvalds/linux/commit/6cc7a7
