### PR TITLE
make sure the files using version.h depend on it being generated first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ endif
 
 all: sslh $(MAN) echosrv
 
-.c.o: *.h
+.c.o: *.h version.h
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<
 
 version.h:
@@ -78,7 +78,7 @@ sslh-select: version.h $(OBJS) sslh-select.o Makefile common.h
 systemd-sslh-generator: systemd-sslh-generator.o
 	$(CC) $(CFLAGS) $(LDFLAGS) -o systemd-sslh-generator systemd-sslh-generator.o -lconfig
 
-echosrv: $(OBJS) echosrv.o
+echosrv: version.h $(OBJS) echosrv.o
 	$(CC) $(CFLAGS) $(LDFLAGS) -o echosrv echosrv.o probe.o common.o tls.o $(LIBS)
 
 $(MAN): sslh.pod Makefile


### PR DESCRIPTION
If the build is running with parallel make, it oftentimes fails with errors. Here's an example execution and resulting error output:

```
$ make -j5 CC=x86_64-pc-linux-gnu-gcc USELIBCAP=caps USELIBWRAP= USESYSTEMD=systemd
./genver.sh >version.h
x86_64-pc-linux-gnu-gcc -Wall -g  -DENABLE_REGEX -DLIBCONFIG -DLIBCAP -DSYSTEMD -c common.c
x86_64-pc-linux-gnu-gcc -Wall -g  -DENABLE_REGEX -DLIBCONFIG -DLIBCAP -DSYSTEMD -c sslh-main.c
x86_64-pc-linux-gnu-gcc -Wall -g  -DENABLE_REGEX -DLIBCONFIG -DLIBCAP -DSYSTEMD -c probe.c
x86_64-pc-linux-gnu-gcc -Wall -g  -DENABLE_REGEX -DLIBCONFIG -DLIBCAP -DSYSTEMD -c tls.c
sslh-main.c:40:9: error: expected ‘,’ or ‘;’ before ‘VERSION’
 "sslh " VERSION "\n" \
         ^
sslh-main.c: In function ‘parse_cmdline’:
sslh-main.c:539:44: error: ‘VERSION’ undeclared (first use in this function)
             printf("%s %s\n", server_type, VERSION);
                                            ^
sslh-main.c:539:44: note: each undeclared identifier is reported only once for each function it appears in
x86_64-pc-linux-gnu-gcc -Wall -g  -DENABLE_REGEX -DLIBCONFIG -DLIBCAP -DSYSTEMD -c sslh-fork.c
make: *** [Makefile:63: sslh-main.o] Error 1
make: *** Waiting for unfinished jobs....
```

This PR fixes that problem.
