### PR TITLE
getopt_long_only does not exist on NetBSD getopt

### DIFF
--- a/echosrv.c
+++ b/echosrv.c
@@ -64,7 +64,7 @@ void parse_cmdline(int argc, char* argv[])
     };
     struct addrinfo **a;
 
-    while ((c = getopt_long_only(argc, argv, "l:p:", options, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "l:p:", options, NULL)) != -1) {
         if (c == 0) continue;
 
         switch (c) {

--- a/sslh-main.c
+++ b/sslh-main.c
@@ -444,7 +444,7 @@ static void cmdline_config(int argc, char* argv[], struct proto** prots)
 #ifdef LIBCONFIG
     optind = 1;
     opterr = 0; /* we're missing protocol options at this stage so don't output errors */
-    while ((c = getopt_long_only(argc, argv, optstr, all_options, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, optstr, all_options, NULL)) != -1) {
         if (c == 'v') {
             verbose++;
         }
@@ -481,7 +481,7 @@ static void parse_cmdline(int argc, char* argv[], struct proto* prots)
     optind = 1;
     opterr = 1;
 next_arg:
-    while ((c = getopt_long_only(argc, argv, optstr, all_options, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, optstr, all_options, NULL)) != -1) {
         if (c == 0) continue;
 
         if (c >= PROT_SHIFT) {


### PR DESCRIPTION
Since, getopt_long_only does not exist on NetBSD getopt I suggest replacing it with getopt_long.
Theses changes come from the official NetBSD package : http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/sslh/
