### PR TITLE
Makefile: fix parallel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,8 @@ version.h:
 
 sslh: sslh-fork sslh-select
 
+$(OBJS): version.h
+
 sslh-fork: version.h $(OBJS) sslh-fork.o Makefile common.h
 	$(CC) $(CFLAGS) $(LDFLAGS) -o sslh-fork sslh-fork.o $(OBJS) $(LIBS)
 	#strip sslh-fork


### PR DESCRIPTION
version.h is included by some .o files, but it is generated. As such, it
must be a dependency of those .o files.

Rather than filter exactly which .o file needs it, just add a generic
dependency for all .o files on version.h.

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>