### PR TITLE
Add support for wildcard ALPN/SNI values

### DIFF
--- a/example.cfg
+++ b/example.cfg
@@ -74,6 +74,9 @@ protocols:
      { name: "regex"; host: "localhost"; port: "1194"; regex_patterns: [ "^\x00[\x0D-\xFF]$", "^\x00[\x0D-\xFF]\x38" ]; },
 # Jabber
      { name: "regex"; host: "localhost"; port: "5222"; regex_patterns: [ "jabber" ]; },
+    
+# Let's Encrypt (tls-sni-* challenges)
+     { name: "tls"; host: "localhost"; port: "letsencrypt-client"; sni_hostnames: [ "*.*.acme.invalid" ];  log_level: 0;},
 
 # Catch-all
      { name: "regex"; host: "localhost"; port: "443"; regex_patterns: [ "" ]; },

--- a/tls.c
+++ b/tls.c
@@ -30,6 +30,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h> /* malloc() */
+#include <fnmatch.h> /* fnmatch() */
 #include "tls.h"
 
 #define TLS_HEADER_LEN 5
@@ -290,7 +291,7 @@ has_match(char** list, const char* name, size_t name_len) {
 
     for (item = list; *item; item++) {
         if (verbose) fprintf(stderr, "matching [%.*s] with [%s]\n", (int)name_len, name, *item);
-        if(!strncmp(*item, name, name_len)) {
+        if(!fnmatch(*item, name, 0)) {
             return 1;
         }
     }


### PR DESCRIPTION
Hi,

This pull request adds support for wildcard ALPN/SNI values in the TLS probe.

This enables sslh to redirect Let's Encrypt `tls-sni-*` challenges to the Let's Encrypt client. These verification requests will request a certificate using a server_name of `xxx.yyy.acme.invalid`, which will vary for each request.

Cheers,
Jon