### PR TITLE
sslh-select: support forking for particular protocols

### DIFF
--- a/probe.c
+++ b/probe.c
@@ -45,16 +45,16 @@ static int is_true(const char *p, int len, struct proto* proto) { return 1; }
 /* Table of protocols that have a built-in probe
  */
 static struct proto builtins[] = {
-    /* description   service  saddr  log_level  keepalive  probe  */
-    { "ssh",         "sshd",   NULL,  1,        0,         is_ssh_protocol},
-    { "openvpn",     NULL,     NULL,  1,        0,         is_openvpn_protocol },
-    { "tinc",        NULL,     NULL,  1,        0,         is_tinc_protocol },
-    { "xmpp",        NULL,     NULL,  1,        0,         is_xmpp_protocol },
-    { "http",        NULL,     NULL,  1,        0,         is_http_protocol },
-    { "ssl",         NULL,     NULL,  1,        0,         is_tls_protocol },
-    { "tls",         NULL,     NULL,  1,        0,         is_tls_protocol },
-    { "adb",         NULL,     NULL,  1,        0,         is_adb_protocol },
-    { "anyprot",     NULL,     NULL,  1,        0,         is_true }
+    /* description   service  saddr  log_level  keepalive  fork  probe  */
+    { "ssh",         "sshd",   NULL,  1,        0,         1,    is_ssh_protocol},
+    { "openvpn",     NULL,     NULL,  1,        0,         1,    is_openvpn_protocol },
+    { "tinc",        NULL,     NULL,  1,        0,         1,    is_tinc_protocol },
+    { "xmpp",        NULL,     NULL,  1,        0,         0,    is_xmpp_protocol },
+    { "http",        NULL,     NULL,  1,        0,         0,    is_http_protocol },
+    { "ssl",         NULL,     NULL,  1,        0,         0,    is_tls_protocol },
+    { "tls",         NULL,     NULL,  1,        0,         0,    is_tls_protocol },
+    { "adb",         NULL,     NULL,  1,        0,         0,    is_adb_protocol },
+    { "anyprot",     NULL,     NULL,  1,        0,         0,    is_true }
 };
 
 static struct proto *protocols;

--- a/probe.h
+++ b/probe.h
@@ -24,6 +24,7 @@ struct proto {
                      * 1: Log incoming connection
                      */
     int keepalive; /* 0: No keepalive ; 1: Set Keepalive for this connection */
+    int fork; /* 0: Connection can run within shared process ; 1: Separate process required for this connection */
 
     /* function to probe that protocol; parameters are buffer and length
      * containing the data to probe, and a pointer to the protocol structure */

--- a/sslh-main.c
+++ b/sslh-main.c
@@ -123,14 +123,15 @@ static void printsettings(void)
     
     for (p = get_first_protocol(); p; p = p->next) {
         fprintf(stderr,
-                "%s addr: %s. libwrap service: %s log_level: %d family %d %d [%s]\n", 
+                "%s addr: %s. libwrap service: %s log_level: %d family %d %d [%s] [%s]\n",
                 p->description, 
                 sprintaddr(buf, sizeof(buf), p->saddr), 
                 p->service,
                 p->log_level,
                 p->saddr->ai_family,
                 p->saddr->ai_addr->sa_family,
-                p->keepalive ? "keepalive" : "");
+                p->keepalive ? "keepalive" : "",
+                p->fork ? "fork" : "");
     }
     fprintf(stderr, "listening on:\n");
     for (a = addr_listen; a; a = a->ai_next) {
@@ -307,6 +308,7 @@ static int config_protocols(config_t *config, struct proto **prots)
                 p->description = name;
                 config_setting_lookup_string(prot, "service", &(p->service));
                 config_setting_lookup_bool(prot, "keepalive", &p->keepalive);
+                config_setting_lookup_bool(prot, "fork", &p->fork);
 
                 if (config_setting_lookup_int(prot, "log_level", &p->log_level) == CONFIG_FALSE) {
                     p->log_level = 1;


### PR DESCRIPTION
The downside of using `sslh-select` as opposed to `sslh-fork` is that it’s hard to update it remotely: you log into SSH via sslh, launch the update command, and then sslh is terminated and takes your SSH connection with it. What if the update went wrong? If the new sslh doesn’t start up, you can’t log back in and you’re screwed!

This patch allows `sslh-select` to fork, much like `sslh-fork` does, for particular protocols that need it (e. g. SSH), while relying solely on `select`, just like it does now, for others (e. g. HTTPS). This can be configured for each protocol individually.

I’m not sure whether it’s better to keep these two commits separate or to squash them.

The shovel function is more complicated than the one in `sslh-fork` because the sockets are nonblocking and some data may be deferred during or before shoveling.