### PR TITLE
Doc update about Transparent proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ tagged. If you need to retain direct access to ssh on port
 22 AND another port (e.g. 2222), and change the above rules
 accordingly.
 
+Also remember that iptables configuration and ip routes and 
+rules won't be necessarily persisted after you reboot. Make 
+sure to save them properly. For example in CentOS7, you would 
+do `iptables-save > /etc/sysconfig/iptables`, and add both 
+`ip` commands to your `/etc/rc.local`.
+
 FreeBSD:
 
 Given you have no firewall defined yet, you can use the following configuration


### PR DESCRIPTION
Advise users to save the configuration of `iptables` and `ip` rules and routes or they risk loosing it after a reboot and/or crash.

Motivation: I inherited a CentOS machine with some services relying on sslh, it worked perfectly fine for months until we had to reboot it. Then everything stopped working and it has taken us days until we have managed to figure out that the ip rule and route described in the documentation was lost on the reboot. 

I think a short comment, like the one I am proposing, in the documentation could save some big headaches to others in the future.