### PR TITLE
Fixup compile using -std=c90

### DIFF
--- a/common.c
+++ b/common.c
@@ -173,7 +173,7 @@ int bind_peer(int fd, int fd_from)
     res = getpeername(fd_from, from.ai_addr, &from.ai_addrlen);
     CHECK_RES_RETURN(res, "getpeername");
     
-    // if the destination is the same machine, there's no need to do bind
+    /* if the destination is the same machine, there's no need to do bind */
     struct ifaddrs *ifaddrs_p = NULL, *ifa;
 
     getifaddrs(&ifaddrs_p);
@@ -201,7 +201,7 @@ int bind_peer(int fd, int fd_from)
                     match = 1;
             }
         }
-        if (match)  // the destination is the same as the source, should not create a transparent bind
+        if (match)  /* the destination is the same as the source, should not create a transparent bind */
             return 0;
     }
 

--- a/tls.c
+++ b/tls.c
@@ -193,7 +193,7 @@ parse_extensions(const struct TLSProtocol *tls_data, const char *data, size_t da
                         last_matched = 1;
                     }
                 } else {
-                    // both can't match
+                    /* both can't match */
                     return -2;
                 }
             } else if (extension_type == 0x10) { /* ALPN */
@@ -207,7 +207,7 @@ parse_extensions(const struct TLSProtocol *tls_data, const char *data, size_t da
                         last_matched = 1;
                     }
                 } else {
-                    // both can't match
+                    /* both can't match */
                     return -2;
                 }
             }


### PR DESCRIPTION
Some minor changes to allow sslh to compile with the `-ansi` option of gcc. (Change the comment marker)
