### PR TITLE
Get libpcre working (and by default)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 VERSION=$(shell ./genver.sh -r)
 ENABLE_REGEX=1  # Enable regex probes
 USELIBCONFIG=1	# Use libconfig? (necessary to use configuration files)
-USELIBPCRE=	# Use libpcre? (needed for regex on musl)
+USELIBPCRE=1	# Use libpcre? (needed for regex on musl)
 USELIBWRAP?=	# Use libwrap?
 USELIBCAP=	# Use libcap?
 USESYSTEMD=     # Make use of systemd socket activation
@@ -38,7 +38,7 @@ endif
 
 ifneq ($(strip $(USELIBPCRE)),)
 	CPPFLAGS+=-DLIBPCRE
-	LIBS:=$(LIBS) -lpcre
+	LIBS:=$(LIBS) -lpcreposix
 endif
 
 ifneq ($(strip $(USELIBCONFIG)),)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 CC ?= gcc
 CFLAGS ?=-Wall -g $(CFLAGS_COV)
 
-LIBS=
+LIBS=-Wl,--as-needed
 OBJS=common.o sslh-main.o probe.o tls.o
 
 ifneq ($(strip $(USELIBWRAP)),)
@@ -38,7 +38,7 @@ endif
 
 ifneq ($(strip $(USELIBPCRE)),)
 	CPPFLAGS+=-DLIBPCRE
-	LIBS:=$(LIBS) -lpcreposix
+	LIBS:=$(LIBS) -Wl,-Bstatic -lpcreposix -Wl,-Bdynamic -lpcre
 endif
 
 ifneq ($(strip $(USELIBCONFIG)),)
@@ -52,7 +52,7 @@ ifneq ($(strip $(USELIBCAP)),)
 endif
 
 ifneq ($(strip $(USESYSTEMD)),)
-        LIBS:=$(LIBS) -lsystemd
+        LIBS:=$(LIBS) -Wl,-Bstatic -lsystemd -Wl,-Bdynamic
         CPPFLAGS+=-DSYSTEMD
 endif
 

--- a/sslh-main.c
+++ b/sslh-main.c
@@ -212,7 +212,7 @@ static void setup_regex_probe(struct proto *p, config_setting_t* probes)
     for (i = 0; i < num_probes; i++) {
         probe_list[i] = malloc(sizeof(*(probe_list[i])));
         expr = config_setting_get_string_elem(probes, i);
-        res = regcomp(probe_list[i], expr, 0);
+        res = regcomp(probe_list[i], expr, REG_EXTENDED);
         if (res) {
             err = malloc(errsize = regerror(res, probe_list[i], NULL, 0));
             regerror(res, probe_list[i], err, errsize);


### PR DESCRIPTION
These patches fix some issues with the regular expression libraries.

1. Switch to "Extended" regexs for the default C library; the "Basic" mode is only there for compatibility. 
2. Actually use the Pcre library; it doesn't, by default, provide the posix interface; to activate it you have to use the libpcreposix library.
3. Turn it on by default so it has to be actually turned off to use the libc library. This is because libpcre's support of binary matching is significantly better than the standard libc version.
