### PR TITLE
Move hexdump to verbose level 2

### DIFF
--- a/probe.c
+++ b/probe.c
@@ -299,7 +299,7 @@ int probe_client_protocol(struct connection *cnx)
      * connection will just fail later normally). */
 
     /* Dump hex values of the packet */
-    if (verbose) {
+    if (verbose>1) {
         fprintf(stderr, "hexdump of incoming packet:\n");
         hexdump(buffer, n);
     }

--- a/sslh-main.c
+++ b/sslh-main.c
@@ -375,7 +375,10 @@ static int config_parse(char *filename, struct addrinfo **listen, struct proto *
         return 1;
     }
 
-    config_lookup_bool(&config, "verbose", &verbose);
+    if(config_lookup_bool(&config, "verbose", &verbose) == CONFIG_FALSE) {
+	config_lookup_int(&config, "verbose", &verbose);
+    }
+
     config_lookup_bool(&config, "inetd", &inetd);
     config_lookup_bool(&config, "foreground", &foreground);
     config_lookup_bool(&config, "numeric", &numeric);


### PR DESCRIPTION
How about this as an update to the hexdump patch; you won't get much simpler.

From the command line you use two "-v" options or in the configuration file you replace the boolean "verbose:true" with an integer "verbose:2". (Verbose:true and verbose:false still work correctly)
