### PR TITLE
Remove use of PCRE wrapper.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Configuration
 
 VERSION=$(shell ./genver.sh -r)
-ENABLE_REGEX=1  # Enable regex probes
+ENABLE_REGEX=   # Enable regex probes
 USELIBCONFIG=1	# Use libconfig? (necessary to use configuration files)
 USELIBPCRE=1	# Use libpcre? (needed for regex on musl)
 USELIBWRAP?=	# Use libwrap?
@@ -40,7 +40,7 @@ endif
 
 ifneq ($(strip $(USELIBPCRE)),)
 	CPPFLAGS+=-DLIBPCRE
-	LIBS:=$(LIBS) -lpcreposix
+	LIBS:=$(LIBS) -lpcre
 endif
 
 ifneq ($(strip $(USELIBCONFIG)),)


### PR DESCRIPTION
If USELIBPCRE is set (the default) then libpcre is called directly.

Looks like it was pretty easy to use the library directly; they even had a nice little `pcredemo.c` file.

Passes the Debian packaging test and tried it with some regexes ...

```
#   # Send SSLv3 and TLS1.0 requests to a special server.
#   { name: "regex"; host: "localhost"; port: "8801"; regex_patterns: [
#       "^\x16\x03[^\x02-\xFF]..\x01\\x00..\x03[^\x02-\xFF]",
#       "^[\x80-\x8f].\x01\x03[^\x02-\xFF]"
#   ]; },

    # Send TLS1.0 requests to special server
    { name: "regex"; host: "localhost"; port: "8802"; regex_patterns: [
        "^\x16\x03[^\x02-\xFF]..\x01\\x00..\x03\x01",
        "^[\x80-\x8f].\x01\x03\x01"
    ]; },

#   # Send SSLv3 requests to a special server.
#   { name: "regex"; host: "localhost"; port: "8801"; regex_patterns: [
#       "^\x16\x03\\x00..\x01\\x00..\x03\\x00",
#       "^[\x80-\x8f].\x01\x03\\x00"
#   ]; },

#   # All TLS connections.
#   { name: "regex"; host: "localhost"; port: "8802"; regex_patterns: [
#       "^\x16\x03[\x01-\xFF]..\x01\\x00..[\x03\x04]",
#       "^[\x80-\x8f].\x01[\\x00\x03][^\x0F-\xFF]"
#   ]; },

    # All TLS and SSL connections.
    { name: "regex"; host: "localhost"; port: "8805"; regex_patterns: [
        "^\x16\x03[^\x10-\xFF]..\x01\\x00..[\x03\x04]",
        "^[\x80-\x8f].\x01[\\x00\x03][^\x0F-\xFF]"
    ]; },

```