### PR TITLE
Ensure that IPv6 socket would listen only for IPv6 connections

### DIFF
--- a/common.c
+++ b/common.c
@@ -144,6 +144,11 @@ int start_listen_sockets(int *sockfd[], struct addrinfo *addr_list)
            check_res_dump(CR_WARN, res, addr, "setsockopt(IP_FREEBIND)");
            }
 
+       if (addr->ai_addr->sa_family == AF_INET6) {
+           res = setsockopt((*sockfd)[i], IPPROTO_IPV6, IPV6_V6ONLY, (char*)&one, sizeof(one));
+           check_res_dump(CR_WARN, res, addr, "setsockopt(IPV6_V6ONLY)");
+       }
+
        res = bind((*sockfd)[i], addr->ai_addr, addr->ai_addrlen);
        check_res_dump(CR_DIE, res, addr, "bind");
 


### PR DESCRIPTION
When transparent mode is enabled and sslh listening on :: IPv6 address then
source origin address is propagated to target application independently if
connection is IPv4 or IPv6.

On Linux by default IPv6 socket can accept also IPv4 connections. More
applications, including OpenSSH server do not accept IPv4 connections on
IPv6 socket and therefore such transparent configuration does not work.
On BSD systems it is turned off by default due to security reasons.

This patch disables IPv4 connections on IPv6 listening sockets. If somebody
needs to have sslh listening on both IPv4 and IPv6 addresses, then still it
is possible by specifying multiple --listen arguments.

I think it is more misleading if option --listen :::443 cause listening on
both IPv4 and IPv6 addresses even IPv4 address was not specified. This can
also cause security related problems for people who do not know about this
fact as documentation does not mentioned this behavior.