### PR TITLE
Fixed parent/child usage after initial fork in sslh-fork.c

### DIFF
--- a/sslh-fork.c
+++ b/sslh-fork.c
@@ -150,11 +150,11 @@ void main_loop(int listen_sockets[], int num_addr_listen)
     for (i = 0; i < num_addr_listen; i++) {
         listener_pid[i] = fork();
         switch(listener_pid[i]) {
-        case 0: break;
+        // Log if fork() fails for some reason
         case -1: log_message(LOG_ERR, "fork failed: err %d: %s\n", errno, strerror(errno));
                  break;
-
-        default:
+        // We're in the child, we have work to do 
+        case 0:
             /* Listening process just accepts a connection, forks, and goes
              * back to listening */
             while (1)
@@ -178,6 +178,10 @@ void main_loop(int listen_sockets[], int num_addr_listen)
                 }
                 close(in_socket);
             }
+	    break;
+	// We're in the parent, we don't need to do anything
+	default:
+	    break;
         }
     }
 


### PR DESCRIPTION
Fixed issue in sslh-fork.c where the parent was being used instead of the child after forking. This was breaking multiple unit tests (on CentOS 7 at least)