### PR TITLE
Use default killmode for systemd

### DIFF
--- a/scripts/systemd.sslh.service
+++ b/scripts/systemd.sslh.service
@@ -5,7 +5,6 @@ After=network.target
 [Service]
 EnvironmentFile=/etc/conf.d/sslh
 ExecStart=/usr/bin/sslh --foreground $DAEMON_OPTS
-KillMode=process
 #Hardening
 PrivateTmp=true
 CapabilityBoundingSet=CAP_SETGID CAP_SETUID CAP_NET_BIND_SERVICE


### PR DESCRIPTION
`killmode=process` will kill the main process but leave behind remaining processes behind (such as those forked as sslh frequently does). This can leave sslh unexpectedly still running after the systemd service has been stopped. Since the remaining processes keep the ports open, then sslh cannot be started again (because the ports are already in use).

Using the default `killmode=control-group` solves this problem by killing all remaining processes when the sslh service is stopped.