### PR TITLE
TCP_FASTOPEN for incoming connections

### DIFF
--- a/common.c
+++ b/common.c
@@ -134,6 +134,10 @@ int start_listen_sockets(int *sockfd[], struct addrinfo *addr_list)
        res = setsockopt((*sockfd)[i], SOL_SOCKET, SO_REUSEADDR, (char*)&one, sizeof(one));
        check_res_dump(CR_DIE, res, addr, "setsockopt(SO_REUSEADDR)");
 
+       int qlen = 5;
+       res = setsockopt((*sockfd)[i], SOL_SOCKET, TCP_FASTOPEN, (char*)&qlen, sizeof(qlen));
+       check_res_dump(CR_WARN, res, addr, "setsockopt(TCP_FASTOPEN)");
+
        if (addr->ai_flags & SO_KEEPALIVE) {
            res = setsockopt((*sockfd)[i], SOL_SOCKET, SO_KEEPALIVE, (char*)&one, sizeof(one));
            check_res_dump(CR_DIE, res, addr, "setsockopt(SO_KEEPALIVE)");

--- a/common.h
+++ b/common.h
@@ -67,6 +67,10 @@
 #define IP_FREEBIND 0
 #endif
 
+#ifndef TCP_FASTOPEN
+#define TCP_FASTOPEN 23 /* Enable FastOpen on listeners */
+#endif
+
 enum connection_state {
     ST_PROBING=1,    /* Waiting for timeout to find where to forward */
     ST_SHOVELING   /* Connexion is established */


### PR DESCRIPTION
Enable TCP Fast Open for listening sockets. If the client making the connection also supports it, it can improve connection speed by eliminating one round trip. If the client doesn't support it, no harm is done.

See https://lwn.net/Articles/508865/ for detailed info
http://edsiper.linuxchile.cl/blog/2013/02/21/linux-tcp-fastopen-in-your-sockets/ provides simple information as to how to implement TCP Fast Open.