### PR TITLE
Use TCP Fast Open for client sockets

### DIFF
--- a/common.c
+++ b/common.c
@@ -277,6 +277,11 @@ int connect_addr(struct connection *cnx, int fd_from)
             log_message(LOG_ERR, "forward to %s failed:socket: %s\n",
                         cnx->proto->name, strerror(errno));
         } else {
+            one = 1;
+            // indicate desire to use TCP Fast Open
+            setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN_CONNECT, &one, sizeof(one));
+            // no need to check return value; if it's not supported, that's okay
+
             if (cfg.transparent) {
                 res = bind_peer(fd, fd_from);
                 CHECK_RES_RETURN(res, "bind_peer");
@@ -288,7 +293,6 @@ int connect_addr(struct connection *cnx, int fd_from)
                 close(fd);
             } else {
                 if (cnx->proto->keepalive) {
-                    one = 1;
                     res = setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, (char*)&one, sizeof(one));
                     CHECK_RES_RETURN(res, "setsockopt(SO_KEEPALIVE)");
                 }

--- a/common.h
+++ b/common.h
@@ -67,6 +67,10 @@
 #define IP_FREEBIND 0
 #endif
 
+#ifndef TCP_FASTOPEN_CONNECT
+#define TCP_FASTOPEN_CONNECT 30 /* Attempt FastOpen with connect.  */
+#endif
+
 enum connection_state {
     ST_PROBING=1,    /* Waiting for timeout to find where to forward */
     ST_SHOVELING   /* Connexion is established */


### PR DESCRIPTION
Set the TCP_FASTOPEN_CONNECT option on client sockets to signal desire to use TCP Fast Open.

See https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=19f6d3f3c8422d65b5e3d2162e30ef07c6e21ea2