### PR TITLE
fix version extraction when building in a larger git tree

### DIFF
--- a/genver.sh
+++ b/genver.sh
@@ -7,7 +7,7 @@ else
 	QUIET=0
 fi
 
-if ! `(git status | grep -q "On branch") 2> /dev/null`; then
+if [ ! -d .git ] || ! `(git status | grep -q "On branch") 2> /dev/null`; then
         # If we don't have git, we can't work out what
         # version this is. It must have been downloaded as a
         # zip file. 
@@ -25,7 +25,7 @@ if ! `(git status | grep -q "On branch") 2> /dev/null`; then
         fi
 fi
 
-if head=`git rev-parse --verify HEAD 2>/dev/null`; then
+if [ -d .git ] && head=`git rev-parse --verify HEAD 2>/dev/null`; then
 	# generate the version info based on the tag
 	release=`(git describe --tags || git --describe || git describe --all --long) \
 		2>/dev/null | tr -d '\n'`


### PR DESCRIPTION
sslh uses host git to extract its own version number. In buildroot, this
is an issue since extracted information is conflicting with buildroot git
status if we use git as VCS for buildroot.

Since these git calls are legitimate only if git is used for the sslh
subtree only, this patch adds a check : a .git directory has to exist at
the root of the project to enable git-extracted version string.

Signed-off-by: David Bachelart <david.bachelart@bbright.com>
[yann.morin.1998@free.fr: fix troll character U+c2a0]
Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/sslh/0001-secure-version-while-building-sslh-in-a-larger-git-t.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>