### PR TITLE
Update Let's Encrypt entry in example.cfg

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,9 @@ vNEXT:
 	use conf2struct. Hopefully this should be transparent
 	to users.
 
+	Update Let's Encrypt entry in example.cfg for tls-alpn-01
+	challenges; tls-sni-* challenges are now deprecated.
+
 v1.20: 20NOV2018
 	Added support for socks5 protocol (Eugene Protozanov)
 

--- a/example.cfg
+++ b/example.cfg
@@ -82,8 +82,8 @@ protocols:
      { name: "tls"; host: "localhost"; port: "993"; sni_hostnames: [ "mail.rutschle.net", "mail.englishintoulouse.com" ]; log_level: 0;  tfo_ok: true },
      { name: "tls"; host: "localhost"; port: "xmpp-client"; sni_hostnames: [ "im.rutschle.net", "im.englishintoulouse.com" ];  log_level: 0; tfo_ok: true },
 
-# Let's Encrypt (tls-sni-* challenges)
-     { name: "tls"; host: "localhost"; port: "letsencrypt-client"; sni_hostnames: [ "*.*.acme.invalid" ];  log_level: 0;},
+# Let's Encrypt (tls-alpn-* challenges)
+     { name: "tls"; host: "localhost"; port: "letsencrypt-client"; alpn_protocols: [ "acme-tls/1" ]; log_level: 0;},
 
 # catch anything else TLS
      { name: "tls"; host: "localhost"; port: "443";  tfo_ok: true },


### PR DESCRIPTION
Update Let's Encrypt entry in example.cfg for tls-alpn-01 challenge.
Previous entry was based on tls-sni-01 challenge which is deprecated and
was disabled in March 2019.

Signed-off-by: Jonathan McCrohan <jmccrohan@gmail.com>