### PR TITLE
Change process name to indicate task of process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ USELIBPCRE=1	# Use libpcre? (needed for regex on musl)
 USELIBWRAP?=	# Use libwrap?
 USELIBCAP=	# Use libcap?
 USESYSTEMD=     # Make use of systemd socket activation
+USELIBBSD?=     # Use libbsd (needed to update process name in `ps`)
 COV_TEST= 	# Perform test coverage?
 PREFIX?=/usr
 BINDIR?=$(PREFIX)/sbin
@@ -57,6 +58,11 @@ ifneq ($(strip $(USESYSTEMD)),)
         LIBS:=$(LIBS) -lsystemd
         CPPFLAGS+=-DSYSTEMD
 	CONDITIONAL_TARGETS+=systemd-sslh-generator
+endif
+
+ifneq ($(strip $(USELIBBSD)),)
+        LIBS:=$(LIBS) -lbsd
+        CPPFLAGS+=-DLIBBSD
 endif
 
 

--- a/common.c
+++ b/common.c
@@ -30,6 +30,10 @@
 #include <systemd/sd-daemon.h>
 #endif
 
+#ifdef LIBBSD
+#include <bsd/unistd.h>
+#endif
+
 /*
  * Settings that depend on the command line or the config file
  */
@@ -619,6 +623,24 @@ void log_connection(struct connection_desc* desc, const struct connection *cnx)
                 desc->service,
                 desc->local,
                 desc->target);
+}
+
+void set_proctitle_shovel(struct connection_desc* desc, const struct connection *cnx)
+{
+#ifdef LIBBSD
+    struct connection_desc d;
+
+    if (!desc) {
+        desc = &d;
+        get_connection_desc(desc, cnx);
+    }
+    setproctitle("shovel %s %s->%s => %s->%s",
+        cnx->proto->name,
+        desc->peer,
+        desc->service,
+        desc->local,
+        desc->target);
+#endif
 }
 
 

--- a/common.h
+++ b/common.h
@@ -123,6 +123,7 @@ char* sprintaddr(char* buf, size_t size, struct addrinfo *a);
 void resolve_name(struct addrinfo **out, char* fullname);
 int get_connection_desc(struct connection_desc* desc, const struct connection *cnx);
 void log_connection(struct connection_desc* desc, const struct connection *cnx);
+void set_proctitle_shovel(struct connection_desc* desc, const struct connection *cnx);
 int check_access_rights(int in_socket, const char* service);
 void setup_signals(void);
 void setup_syslog(const char* bin_name);

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -27,6 +27,9 @@ distclean` for example), you will also need to add
 [conf2struct](https://www.rutschle.net/tech/conf2struct/README.html)
 (v1.0) to your path.
 
+There is optional support to change the process name (as shown in `ps`),
+which requires `libbsd` at runtime, and `libbsd-dev` at compile-time.
+
 Compilation
 -----------
 
@@ -47,6 +50,9 @@ of the Makefile:
 
 *  `USESYSTEMD` compiles support for using systemd socket activation.
    You will need `systemd` headers to compile (`systemd-devel` in Fedora).
+
+* `USELIBBSD` compiles support for updating the process name (as shown
+  by `ps`).
 
 Binaries
 --------

--- a/sslh-main.c
+++ b/sslh-main.c
@@ -33,6 +33,10 @@
 #endif
 #endif
 
+#ifdef LIBBSD
+#include <bsd/unistd.h>
+#endif
+
 #include "common.h"
 #include "probe.h"
 
@@ -247,7 +251,7 @@ void config_sanity_check(struct sslhcfg_item* cfg) {
 }
 
 
-int main(int argc, char *argv[])
+int main(int argc, char *argv[], char* envp[])
 {
 
    extern char *optarg;
@@ -255,6 +259,9 @@ int main(int argc, char *argv[])
    int res, num_addr_listen;
    int *listen_sockets;
 
+#ifdef LIBBSD
+   setproctitle_init(argc, argv, envp);
+#endif
 
    memset(&cfg, 0, sizeof(cfg));
    sslhcfg_cl_parse(argc, argv, &cfg);


### PR DESCRIPTION
This PR solves issue #239

It turned out that `prctl()` wasn't sufficient. I've used `libbsd` instead. Since this is an additional dependency, I've disabled it by default in the Makefile. Build with `USELIBBSD=1` to enable the process renaming in forking mode. Tested with IPv4 & IPv6 addresses.

Sample output:
```
./sslh-fork -nf -p 0.0.0.0:443 -p [::]:443 --ssh 127.0.0.1:22 --tls 127.0.0.1:1443 --openvpn 127.0.0.1:1194
 \_ sslh-fork: listener 0.0.0.0:443
 |   \_ sslh-fork: shovel ssh 192.0.2.123:39360->192.0.2.1:443 => 127.0.0.1:48092->127.0.0.1:22
 \_ sslh-fork: listener :::443
```