### PR TITLE
Fix warnings

### DIFF
--- a/common.c
+++ b/common.c
@@ -97,12 +97,12 @@ int make_listen_tfo(int s)
 
     /* Don't do it if not supported */
     if (!TCP_FASTOPEN)
-        return;
+        return 0;
 
     /* Don't do it if any protocol does not specify it */
     for (i = 0; i < cfg.protocols_len; i++) {
         if (! cfg.protocols[i].tfo_ok)
-            return;
+            return 0;
     }
 
     return setsockopt(s, SOL_SOCKET, TCP_FASTOPEN, (char*)&qlen, sizeof(qlen));

--- a/sslh-main.c
+++ b/sslh-main.c
@@ -224,11 +224,11 @@ static void config_protocols()
             cfg.protocols[i].data = (void*)new_tls_data();
             if (cfg.protocols[i].sni_hostnames_len)
                 tls_data_set_list(cfg.protocols[i].data, 0,
-                                  cfg.protocols[i].sni_hostnames,
+                                  (const char**) cfg.protocols[i].sni_hostnames,
                                   cfg.protocols[i].sni_hostnames_len);
             if (cfg.protocols[i].alpn_protocols_len)
                 tls_data_set_list(cfg.protocols[i].data, 1, 
-                                  cfg.protocols[i].alpn_protocols,
+                                  (const char**) cfg.protocols[i].alpn_protocols,
                                   cfg.protocols[i].alpn_protocols_len);
         }
     }

--- a/sslh-main.c
+++ b/sslh-main.c
@@ -115,7 +115,7 @@ static void printsettings(void)
 }
 
 
-/* To removed in v1.21 */
+/* To be removed in v1.21 */
 const char* ssl_err_msg = "Usage of 'ssl' setting is deprecated and will be removed in v1.21. Please use 'tls' instead\n";
 void ssl_to_tls(char* setting)
 {
@@ -126,7 +126,7 @@ void ssl_to_tls(char* setting)
 }
 
 
-/* Turn 'ssl' command line option to 'tls'. To removed in v1.21 */
+/* Turn 'ssl' command line option to 'tls'. To be removed in v1.21 */
 void cmd_ssl_to_tls(int argc, char* argv[])
 {
     int i;
@@ -135,7 +135,7 @@ void cmd_ssl_to_tls(int argc, char* argv[])
             strcpy(argv[i], "--tls");
             /* foreground option not parsed yet, syslog not open, just print on
              * stderr and hope for the best */
-            fprintf(stderr, ssl_err_msg);
+            fprintf(stderr, "%s", ssl_err_msg);
         }
     }
 }


### PR DESCRIPTION
When compiling on macOS 10.15, I get a couple of warnings, specifically about `return-type`, `incompatible-pointer-types-discards-qualifiers` and `format-security`. This pull request tries to fix these (I hope without changing any of the function). Please review.

My compiler is:

```sh
$ gcc --version
Apple LLVM version 10.0.1 (clang-1001.0.46.4)
Target: x86_64-apple-darwin18.7.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```
