### PR TITLE
Update SSL example to TLS

### DIFF
--- a/basic.cfg
+++ b/basic.cfg
@@ -24,7 +24,7 @@ protocols:
      { name: "openvpn"; host: "localhost"; port: "1194"; },
      { name: "xmpp"; host: "localhost"; port: "5222"; },
      { name: "http"; host: "localhost"; port: "80"; },
-     { name: "ssl"; host: "localhost"; port: "443"; log_level: 0; },
+     { name: "tls"; host: "localhost"; port: "443"; log_level: 0; },
      { name: "anyprot"; host: "localhost"; port: "443"; }
 );
 


### PR DESCRIPTION
Just a minor amend, the example basic cfg file uses "ssl", which will throw a deprecation type message, I've updated it to "tls".