### PR TITLE
Always initialize config_t structure, fixes #270

### DIFF
--- a/sslh-conf.c
+++ b/sslh-conf.c
@@ -1432,7 +1432,6 @@ static int read_compounds(config_setting_t* cfg,
 static int c2s_parse_file(const char* filename, config_t* c, char**errmsg)
 {
     /* Read config file */
-    config_init(c);
     if (config_read_file(c, filename) == CONFIG_FALSE) {
         if (config_error_line(c) != 0) {
            asprintf(errmsg, "%s:%d:%s", 
@@ -1488,7 +1487,7 @@ int sslhcfg_cl_parse(int argc, char* argv[], struct sslhcfg_item* cfg)
         return 0;
     }
 
-
+    config_init(&c);
     if (sslhcfg_conffile->count) {
         if (!c2s_parse_file(sslhcfg_conffile->filename[0], &c, &errmsg)) {
             fprintf(stderr, "%s\n", errmsg);


### PR DESCRIPTION
Without this change the config_t structure is ONLY initialized when it
meets a specific criterion. If this criterion is not met the config_t
structure is still used, which can cause a segmentation fault.

Fixes #270.