### PR TITLE
Correct wrong version of pcre in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN \
     libconfig-dev \
     make \
     musl-dev \
-    pcre-dev \
+    pcre2-dev \
     perl && \
   cd /sslh && \
   make sslh-select && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN \
     libconfig-dev \
     make \
     musl-dev \
-    pcre2-dev \
+    pcre2-dev \ 
     perl && \
   cd /sslh && \
   make sslh-select && \
@@ -18,6 +18,6 @@ FROM alpine:latest
 
 COPY --from=build /sslh/sslh-select /sslh
 
-RUN apk --no-cache add libconfig pcre
+RUN apk --no-cache add libconfig pcre2
 
 ENTRYPOINT [ "/sslh", "--foreground"]


### PR DESCRIPTION
Creating the dockerfile fails because of wrong version of pcre
```
sslh-conf.c:43:10: fatal error: pcre2.h: No such file or directory
   43 | #include <pcre2.h>
```

Updating to pcre2-dev in dockerfile fixes the problem