### PR TITLE
fix build with gcc 4.8

### DIFF
--- a/common.c
+++ b/common.c
@@ -725,10 +725,11 @@ void set_keepcaps(int val) {
 static int use_transparent(void)
 {
 #ifdef LIBCAP
+    int i;
     if (cfg.transparent)
         return 1;
 
-    for (int i = 0; i < cfg.protocols_len; i++)
+    for (i = 0; i < cfg.protocols_len; i++)
         if (cfg.protocols[i].transparent)
             return 1;
 

--- a/gap.c
+++ b/gap.c
@@ -45,6 +45,7 @@ static int gap_len_alloc(int elem_size)
 /* Creates a new gap at least `len` big, all pointers are initialised at NULL */
 gap_array* gap_init(int len)
 {
+    int i;
     gap_array* gap = malloc(sizeof(*gap));
     if (!gap) return NULL;
     memset(gap, 0, sizeof(*gap));
@@ -55,7 +56,7 @@ gap_array* gap_init(int len)
     gap->array = malloc(gap->len * elem_size);
     if (!gap->array) return NULL;
 
-    for (int i = 0; i < gap->len; i++)
+    for (i = 0; i < gap->len; i++)
         gap->array[i] = NULL;
 
     return gap;
@@ -68,6 +69,7 @@ void* gap_get(gap_array* gap, int index)
 
 static int gap_extend(gap_array* gap)
 {
+    int i;
     int elem_size = sizeof(gap->array[0]);
     int new_length = gap->len + gap_len_alloc(elem_size);
     void** new = realloc(gap->array, new_length * elem_size);
@@ -75,7 +77,7 @@ static int gap_extend(gap_array* gap)
 
     gap->array = new;
 
-    for (int i = gap->len; i < new_length; i++) {
+    for (i = gap->len; i < new_length; i++) {
         gap->array[i] = NULL;
     }
 

--- a/sslh-ev.c
+++ b/sslh-ev.c
@@ -50,6 +50,7 @@ static void cnx_accept_cb(EV_P_ ev_io *w, int revents);
 static void watchers_init(watchers** w, struct listen_endpoint* listen_sockets, 
                           int num_addr_listen)
 {
+    int i;
     *w = malloc(sizeof(**w));
     (*w)->ev_ior = gap_init(num_addr_listen);
     (*w)->ev_iow = gap_init(num_addr_listen);
@@ -57,7 +58,7 @@ static void watchers_init(watchers** w, struct listen_endpoint* listen_sockets,
     (*w)->fd2ls = gap_init(0);
 
     /* Create watchers for listen sockets */
-    for (int i = 0; i < num_addr_listen; i++) {
+    for (i = 0; i < num_addr_listen; i++) {
         ev_io* io = malloc(sizeof(*io));
 
         ev_io_init(io, &cnx_accept_cb, listen_sockets[i].socketfd, EV_READ);

--- a/sslh-select.c
+++ b/sslh-select.c
@@ -50,11 +50,12 @@ struct watchers {
 static void watchers_init(watchers** w, struct listen_endpoint* listen_sockets,
                           int num_addr_listen)
 {
+    int i;
     *w = malloc(sizeof(**w));
     FD_ZERO(&(*w)->fds_r);
     FD_ZERO(&(*w)->fds_w);
 
-    for (int i = 0; i < num_addr_listen; i++) {
+    for (i = 0; i < num_addr_listen; i++) {
         watchers_add_read(*w, listen_sockets[i].socketfd);
         set_nonblock(listen_sockets[i].socketfd);
     }

--- a/udp-listener.c
+++ b/udp-listener.c
@@ -52,13 +52,14 @@ static int udp_timeout(struct connection* cnx)
  * */
 void udp_timeouts(struct loop_info* fd_info)
 {
+    int i;
     time_t now = time(NULL);
 
     if (now < fd_info->next_timeout) return;
 
     time_t next_timeout = INT_MAX;
 
-    for (int i = 0; i < watchers_maxfd(fd_info->watchers); i++) {
+    for (i = 0; i < watchers_maxfd(fd_info->watchers); i++) {
         /* if it's either in read or write set, there is a connection
          * behind that file descriptor */
         struct connection* cnx = collection_get_cnx_from_fd(fd_info->collection, i);


### PR DESCRIPTION
Fix the following build failure with gcc 4.8:

```
sslh-select.c: In function 'udp_timeouts':
sslh-select.c:480:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for (int i = 0; i < fd_info->max_fd; i++) {
     ^
```

Fixes:
 - http://autobuild.buildroot.org/results/4315321fb1b6c6849ff583999557106fb97b3ab7

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>