### PR TITLE
docs: corrections to docker usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,19 +50,18 @@ Build docker image
 
 
 ```bash
-docker container run \
+docker run \
   --rm \
   -it \
+  sslh:latest \
   --listen=0.0.0.0:443 \
   --ssh=hostname:22 \
-  --tlshostname:443 \
-  sslh:latest
+  --tls=hostname:443
 ```
 
 docker-compose example
 
 ```
----
 version: "3"
 
 services:
@@ -70,19 +69,17 @@ services:
     image: sslh:latest
     hostname: sslh
     ports:
-      - 443:443/tcp
-    command: --listen=0.0.0.0:443 --tlshostname:443 --openvpn=openvpn:1194
+      - 443:443
+    command: --listen=0.0.0.0:443 --tls=nginx:443 --openvpn=openvpn:1194
     depends_on:
       - nginx
       - openvpn
 
   nginx:
     image: nginx
-    hostname: nginx
 
   openvpn:
-    image: openvpn:latest
-    hostname: openvpn
+    image: openvpn
 ```
 
 Comments? Questions?


### PR DESCRIPTION
Hello, thanks for this tool!
The README sections for both the `docker run` and `docker compose` needed a little correction. Specifically:

- The arguments to `docker run` were out of order (the docker image name must precede the commands that are to be fed into its entry point (in this case sslh).
- An '=' was missing in `--tls=hostname`
- Removed the hostname directive for nginx and openvpn services as it is not needed here (containers find eachother by their service name)
