### PR TITLE
Update README.MacOSX

### DIFF
--- a/doc/README.MacOSX
+++ b/doc/README.MacOSX
@@ -33,7 +33,7 @@ with launchctl or simply reboot.
 		<string>0.0.0.0:443</string>
 		<string>--ssh</string>
 		<string>localhost:22</string>
-		<string>--ssl</string>
+		<string>--tls</string>
 		<string>localhost:443</string>
 	</array>
 	<key>QueueDirectories</key>


### PR DESCRIPTION
Should be *tls* as argument here instead of old *ssl* no ?