### PR TITLE
Fixes unitialised memory access as seen in issue #355.

### DIFF
--- a/sslh-select.c
+++ b/sslh-select.c
@@ -52,6 +52,9 @@ static void watchers_init(watchers** w, struct listen_endpoint* listen_sockets,
                           int num_addr_listen)
 {
     *w = malloc(sizeof(**w));
+    CHECK_ALLOC(*w, "malloc");
+
+    memset(*w, 0, sizeof(**w));
     FD_ZERO(&(*w)->fds_r);
     FD_ZERO(&(*w)->fds_w);
 


### PR DESCRIPTION
==1391== Conditional jump or move depends on uninitialised value(s)
==1391==    at 0x10E92F: watchers_add_read (sslh-select.c:67)
==1391==    by 0x10E92F: watchers_init (sslh-select.c:59)
==1391==    by 0x10E92F: main_loop (sslh-select.c:134)
==1391==    by 0x10DB6D: main (sslh-main.c:285)

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>