### PR TITLE
docker: Add proper entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,5 @@ RUN apk --no-cache add libconfig pcre2
 
 COPY "./container-entrypoint.sh" "/init"
 ENTRYPOINT [ "/init" ]
+
+USER nobody:nogroup

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,5 @@ COPY --from=build "/sslh/sslh-select" "/usr/local/bin/sslh"
 
 RUN apk --no-cache add libconfig pcre2
 
-ENTRYPOINT [ "/usr/local/bin/sslh" ]
+COPY "./container-entrypoint.sh" "/init"
+ENTRYPOINT [ "/init" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ COPY --from=build "/sslh/sslh-select" "/usr/local/bin/sslh"
 
 RUN apk --no-cache add libconfig pcre2
 
-ENTRYPOINT [ "/usr/local/bin/sslh", "--foreground" ]
+ENTRYPOINT [ "/usr/local/bin/sslh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:latest as build
 
-ADD . /sslh
+WORKDIR /sslh
 
+COPY . /sslh
 RUN \
   apk add \
     gcc \
@@ -10,14 +11,13 @@ RUN \
     musl-dev \
     pcre2-dev \
     perl && \
-  cd /sslh && \
   make sslh-select && \
   strip sslh-select
 
 FROM alpine:latest
 
-COPY --from=build /sslh/sslh-select /sslh
+COPY --from=build "/sslh/sslh-select" "/usr/local/bin/sslh"
 
 RUN apk --no-cache add libconfig pcre2
 
-ENTRYPOINT [ "/sslh", "--foreground"]
+ENTRYPOINT [ "/usr/local/bin/sslh", "--foreground" ]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ How to use
 
 ```bash
 docker run \
+  --cap-add CAP_NET_RAW \
+  --cap-add CAP_NET_BIND_SERVICES \
   --rm \
   -it \
   ghcr.io/yrutschle/sslh:latest \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ protocol that can be tested using a regular expression, can
 be recognised. A typical use case is to allow serving
 several services on port 443 (e.g. to connect to SSH from
 inside a corporate firewall, which almost never block port
-443) while still serving HTTPS on that port. 
+443) while still serving HTTPS on that port.
 
 Hence `sslh` acts as a protocol demultiplexer, or a
 switchboard. With the SNI and ALPN probe, it makes a good
@@ -20,8 +20,8 @@ address.
 
 `sslh` has the bells and whistles expected from a mature
 daemon: privilege and capabilities dropping, inetd support,
-systemd support, transparent proxying, chroot, logging, 
-IPv4 and IPv6, TCP and UDP, a fork-based and a select-based 
+systemd support, transparent proxying, chroot, logging,
+IPv4 and IPv6, TCP and UDP, a fork-based and a select-based
 model, and more.
 
 Install
@@ -50,6 +50,7 @@ docker run \
   --rm \
   -it \
   ghcr.io/yrutschle/sslh:latest \
+  --foreground \
   --listen=0.0.0.0:443 \
   --ssh=hostname:22 \
   --tls=hostname:443
@@ -66,7 +67,7 @@ services:
     hostname: sslh
     ports:
       - 443:443
-    command: --listen=0.0.0.0:443 --tls=nginx:443 --openvpn=openvpn:1194
+    command: --foreground --listen=0.0.0.0:443 --tls=nginx:443 --openvpn=openvpn:1194
     depends_on:
       - nginx
       - openvpn

--- a/container-entrypoint.sh
+++ b/container-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL2-or-later
+#
+# Copyright (C) 2023 Olliver Schinagl <oliver@schinagl.nl>
+#
+# A beginning user should be able to docker run image bash (or sh) without
+# needing to learn about --entrypoint
+# https://github.com/docker-library/official-images#consistency
+
+set -eu
+
+bin='sslh'
+
+# run command if it is not starting with a "-" and is an executable in PATH
+if [ "${#}" -le 0 ] || \
+   [ "${1#-}" != "${1}" ] || \
+   [ -d "${1}" ] || \
+   ! command -v "${1}" > '/dev/null' 2>&1; then
+	entrypoint='true'
+fi
+
+exec ${entrypoint:+${bin}} "${@}"
+
+exit 0


### PR DESCRIPTION
As per docker guidelines [0] a container should always really have a consistent entrypoint, without having to override it or do special tricks.

The behavior should be _identical_ as before, but will no longer trigger errors because sslh doesn't understand certain parameters (/bin/sh for example being common). Further more, allows a proper entrypoint for a CI to work easily with the container as well. Allowing for scenario's such as `apk add git && sslh --foreground` in your sslh image for example.

E.g. `docker run sslh --help` works though with the default `--foreground` a bit weirdly, as does `docker run sslh /bin/sh` or `docker run sslh ls`.

[0]: https://github.com/docker-library/official-images#consistency