### PR TITLE
docker: Automatically build and push container

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -1,0 +1,72 @@
+name: Create and publish Container image
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: true
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/386
+          - linux/arm64
+          - linux/arm/v6
+          - linux/arm/v7
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=edge
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          platforms: ${{ matrix.platform }}
+          context: .
+          file: Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -44,16 +44,12 @@ How to use
 
 ---
 
-Build docker image
-
-    make docker
-
 
 ```bash
 docker run \
   --rm \
   -it \
-  sslh:latest \
+  ghcr.io/yrutschle/sslh:latest \
   --listen=0.0.0.0:443 \
   --ssh=hostname:22 \
   --tls=hostname:443


### PR DESCRIPTION
The current sslh container works fine, but needs to be created manually and locally by the user. Instead, let the pipeline do the dirty work and push it to this repo's own registry.

This simplifies #361 and fixes some issues with that MR.

Closes #361 and #360 and #334.