### PR TITLE
CI: Do not parallelized container builds

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -20,15 +20,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: true
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/386
-          - linux/arm64
-          - linux/arm/v6
-          - linux/arm/v7
 
     steps:
       - name: Checkout repository
@@ -64,7 +55,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v6,linux/arm/v7
           context: .
           file: Dockerfile
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
To my great embarasement I just noticed that I mis-understood how matrixes and parallel builds work.

A matrix kicks of multiple jobs in parallel. The matrix (row if you like) kicks off a number of pipeline jobs (columns) and thus in effect, runs them all nicely in parallel. However, when doing this with docker images, you need to 'merge' them together again, if you want 'docker run image:latest' to just magically work. An alternative, would be to push image:<arch> however.

Regardless, the pipeline can very easily generate a multi-arch build, if you don't parallelize and split them. The resulting container and tags behave properly. From the previous job, all containers can be pulled and work; its just that the 'master' tag, points to whatever was pushed last.

So I apologize for missing this, I should have known better.