### PR TITLE
version: Do not put a slash in the version tag

### DIFF
--- a/genver.sh
+++ b/genver.sh
@@ -10,12 +10,12 @@ fi
 if [ ! -d .git ] || ! `(git status | grep -q "On branch") 2> /dev/null`; then
         # If we don't have git, we can't work out what
         # version this is. It must have been downloaded as a
-        # zip file. 
-        
+        # zip file.
+
         # If downloaded from the release page, the directory
         # has the version number.
         release=`pwd | sed s/.*sslh-// | grep "[[:digit:]]"`
-        
+
         if [ "x$release" = "x" ]; then
             # If downloaded from the head, Github creates the
             # zip file with all files dated from the last
@@ -28,7 +28,7 @@ fi
 if [ -d .git ] && head=`git rev-parse --verify HEAD 2>/dev/null`; then
 	# generate the version info based on the tag
 	release=`(git describe --tags || git --describe || git describe --all --long) \
-		2>/dev/null | tr -d '\n'`
+		2>/dev/null | tr -s '/' '-' | tr -d '\n'`
 
 	# Are there uncommitted changes?
 	git update-index --refresh --unmerged > /dev/null


### PR DESCRIPTION
Many systems do not like having a `/` in the version tag. In some cases, we generate a version as `head/branch`, which even gets amplified if one uses `dev/feature` as a branch name.

So lets drop these slashes to avoid potential issues.

Closes #358