### PR TITLE
Enable --transparent mode for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
 FROM alpine:latest as build
 
 WORKDIR /sslh
-COPY . /sslh
 
 RUN apk add gcc libconfig-dev make musl-dev pcre2-dev perl
+
+COPY . /sslh
 RUN make sslh-select && strip sslh-select
 
 FROM alpine:latest
 
-COPY --from=build "/sslh/sslh-select" "/usr/local/bin/sslh"
-
 RUN apk --no-cache add libconfig pcre2 iptables ip6tables libcap
 
 RUN adduser sslh --shell /bin/sh --disabled-password
+
+COPY --from=build "/sslh/sslh-select" "/usr/local/bin/sslh"
 RUN setcap cap_net_bind_service,cap_net_raw+ep /usr/local/bin/sslh
 
 COPY "./container-entrypoint.sh" "/init"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,22 @@
 FROM alpine:latest as build
 
 WORKDIR /sslh
-
 COPY . /sslh
-RUN \
-  apk add \
-    gcc \
-    libconfig-dev \
-    make \
-    musl-dev \
-    pcre2-dev \
-    perl && \
-  make sslh-select && \
-  strip sslh-select
+
+RUN apk add gcc libconfig-dev make musl-dev pcre2-dev perl
+RUN make sslh-select && strip sslh-select
 
 FROM alpine:latest
 
 COPY --from=build "/sslh/sslh-select" "/usr/local/bin/sslh"
 
-RUN apk --no-cache add libconfig pcre2
+RUN apk --no-cache add libconfig pcre2 iptables ip6tables libcap
+
+RUN adduser sslh --shell /bin/sh --disabled-password
+RUN setcap cap_net_bind_service,cap_net_raw+ep /usr/local/bin/sslh
 
 COPY "./container-entrypoint.sh" "/init"
 ENTRYPOINT [ "/init" ]
 
-USER nobody:nogroup
+# required for updating iptables
+USER root:root

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ version: "3"
 
 services:
   sslh:
-    build: https://github.com/klementng/sslh.git
+    build: https://github.com/yrutschle/sslh.git
     container_name: sslh
     environment:
       - TZ=${TZ}
@@ -129,7 +129,7 @@ version: "3"
 
 services:
   sslh:
-    build: https://github.com/klementng/sslh.git
+    build: https://github.com/yrutschle/sslh.git
     container_name: sslh
     environment:
       - TZ=${TZ}

--- a/container-entrypoint.sh
+++ b/container-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 # SPDX-License-Identifier: GPL2-or-later
 #
 # Copyright (C) 2023 Olliver Schinagl <oliver@schinagl.nl>
@@ -19,6 +20,73 @@ if [ "${#}" -le 0 ] || \
 	entrypoint='true'
 fi
 
-exec ${entrypoint:+${bin}} "${@}"
+############################################################################
+
+unconfigure_iptables() { 
+   set +e # Don't exit  
+
+   echo "Received SIG TERM/INT/KILL. Removing iptables / routing changes"
+
+   iptables -t raw -D PREROUTING ! -i lo -d 127.0.0.0/8 -j DROP
+   iptables -t mangle -D POSTROUTING ! -o lo -s 127.0.0.0/8 -j DROP
+
+   iptables -t nat -D OUTPUT -m owner --uid-owner sslh -p tcp --tcp-flags FIN,SYN,RST,ACK SYN -j CONNMARK --set-xmark 0x01/0x0f
+   iptables -t mangle -D OUTPUT ! -o lo -p tcp -m connmark --mark 0x01/0x0f -j CONNMARK --restore-mark --mask 0x0f
+
+   ip rule del fwmark 0x1 lookup 100
+   ip route del local 0.0.0.0/0 dev lo table 100
+
+
+   ip6tables -t raw -D PREROUTING ! -i lo -d ::1/128 -j DROP & > /dev/null #silence ipv6 errors
+   ip6tables -t mangle -D POSTROUTING ! -o lo -s ::1/128 -j DROP & > /dev/null
+   ip6tables -t nat -D OUTPUT -m owner --uid-owner sslh -p tcp --tcp-flags FIN,SYN,RST,ACK SYN -j CONNMARK --set-xmark 0x01/0x0f & > /dev/null
+   ip6tables -t mangle -D OUTPUT ! -o lo -p tcp -m connmark --mark 0x01/0x0f -j CONNMARK --restore-mark --mask 0x0f & > /dev/null
+
+   ip -6 rule del fwmark 0x1 lookup 100 & > /dev/null
+   ip -6 route del local ::/0 dev lo table 100 & > /dev/null
+   
+   set -e
+}
+
+configure_iptables() {
+   set +e # Don't exit if rule exist or ipv6 not enabled
+
+   echo "Configuring iptables and routing..."
+
+   iptables -t raw -A PREROUTING ! -i lo -d 127.0.0.0/8 -j DROP
+   iptables -t mangle -A POSTROUTING ! -o lo -s 127.0.0.0/8 -j DROP
+
+   iptables -t nat -A OUTPUT -m owner --uid-owner sslh -p tcp --tcp-flags FIN,SYN,RST,ACK SYN -j CONNMARK --set-xmark 0x01/0x0f
+   iptables -t mangle -A OUTPUT ! -o lo -p tcp -m connmark --mark 0x01/0x0f -j CONNMARK --restore-mark --mask 0x0f
+
+   ip rule add fwmark 0x1 lookup 100
+   ip route add local 0.0.0.0/0 dev lo table 100
+
+   ip6tables -t raw -A PREROUTING ! -i lo -d ::1/128 -j DROP & > /dev/null #silence ipv6 errors
+   ip6tables -t mangle -A POSTROUTING ! -o lo -s ::1/128 -j DROP & > /dev/null
+   ip6tables -t nat -A OUTPUT -m owner --uid-owner sslh -p tcp --tcp-flags FIN,SYN,RST,ACK SYN -j CONNMARK --set-xmark 0x01/0x0f & > /dev/null
+   ip6tables -t mangle -A OUTPUT ! -o lo -p tcp -m connmark --mark 0x01/0x0f -j CONNMARK --restore-mark --mask 0x0f & > /dev/null
+
+   ip -6 rule add fwmark 0x1 lookup 100 & > /dev/null
+   ip -6 route add local ::/0 dev lo table 100 & > /dev/null
+   
+   set -e
+}
+
+for i in "$@" ; do
+    if [ "${i}" = "--transparent" ] ; then
+        echo "--transparent is set"
+        configure_iptables
+        trap unconfigure_iptables TERM INT KILL
+        break
+    fi
+done
+
+#run command as sslh user
+command="${entrypoint:+${bin}} ${@}"
+echo "executing with user 'sslh': $command"
+
+exec su - sslh -c "$command" &
+wait $!
 
 exit 0


### PR DESCRIPTION
This PR enables the use of --transparent flag for docker containers using either sslh container as the main networking container or setting the network_mode=host.

Files changed:
- README.txt : Added Examples
- Dockerfile: Added dependencies, creating user 'sslh', etc.
- container-entrypoint.sh: Implemented automatic adding / removal of iptables / routing rules