### PR TITLE
Docker: ipv6 transparent patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ services:
     sysctls:
       - net.ipv4.conf.default.route_localnet=1
       - net.ipv4.conf.all.route_localnet=1
-    command: --transparent --foreground --listen=0.0.0.0:443 --tls=localhost:8443 --openvpn=localhost:1194 --wireguard=localbox:51820
+    command: --transparent --foreground --listen=0.0.0.0:443 --tls=localhost:8443 --openvpn=localhost:1194
     ports:
       - 443:443 #sslh
 
       - 80:80 #nginx
       - 8443:8443 #nginx
 
-      - 1194:1994 #openvpn
+      - 1194:1194 #openvpn
     extra_hosts:
       - localbox:host-gateway
     restart: unless-stopped
@@ -141,11 +141,22 @@ services:
     #sysctls:
     #  - net.ipv4.conf.default.route_localnet=1
     #  - net.ipv4.conf.all.route_localnet=1
-    command: --transparent --foreground --listen=0.0.0.0:443 --tls=localhost:8443 --openvpn=localhost:1194 --wireguard=localhost:51820
+    command: --transparent --foreground --listen=0.0.0.0:443 --tls=localhost:8443 --openvpn=localhost:1194
     network_mode: host
     restart: unless-stopped
-```
+  
+  nginx:
+    image: nginx:latest
+    .....
+    ports:
+      - 8443:8443 # bind to docker host on port 8443
 
+  openvpn:
+    image: openvpn:latest
+    .....
+    ports:
+      - 1194:1194 # bind to docker host on port 1194
+```
 
 Comments? Questions?
 ====================

--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ services:
     image: openvpn
 ```
 
-Transparent mode 1: shared containers
+Transparent mode 1: using sslh container for networking
 
+_Note: For transparent mode to work, the sslh container must be able to reach your services via **localhost**_
 ```yaml
 version: "3"
 
@@ -114,7 +115,8 @@ services:
   nginx:
     image: nginx:latest
     .....
-    network_mode: service:sslh #set nginx container to use sslh networking
+    network_mode: service:sslh #set nginx container to use sslh networking.
+    # ^^^ This is required. This makes nginx reachable by sslh via localhost
   
   openvpn:
     image: openvpn:latest
@@ -122,7 +124,7 @@ services:
     network_mode: service:sslh #set openvpn container to use sslh networking
 ```
 
-Transparent mode 2: host networking
+Transparent mode 2: using host networking
 
 ```yaml
 version: "3"

--- a/container-entrypoint.sh
+++ b/container-entrypoint.sh
@@ -23,54 +23,62 @@ fi
 ############################################################################
 
 unconfigure_iptables() { 
-   set +e # Don't exit  
+    echo "Received SIG TERM/INT/KILL. Removing iptables / routing changes"
 
-   echo "Received SIG TERM/INT/KILL. Removing iptables / routing changes"
+    set +e # Don't exit if got error
+    set -x
 
-   iptables -t raw -D PREROUTING ! -i lo -d 127.0.0.0/8 -j DROP
-   iptables -t mangle -D POSTROUTING ! -o lo -s 127.0.0.0/8 -j DROP
+    iptables -t raw -D PREROUTING ! -i lo -d 127.0.0.0/8 -j DROP
+    iptables -t mangle -D POSTROUTING ! -o lo -s 127.0.0.0/8 -j DROP
 
-   iptables -t nat -D OUTPUT -m owner --uid-owner sslh -p tcp --tcp-flags FIN,SYN,RST,ACK SYN -j CONNMARK --set-xmark 0x01/0x0f
-   iptables -t mangle -D OUTPUT ! -o lo -p tcp -m connmark --mark 0x01/0x0f -j CONNMARK --restore-mark --mask 0x0f
+    iptables -t nat -D OUTPUT -m owner --uid-owner sslh -p tcp --tcp-flags FIN,SYN,RST,ACK SYN -j CONNMARK --set-xmark 0x01/0x0f
+    iptables -t mangle -D OUTPUT ! -o lo -p tcp -m connmark --mark 0x01/0x0f -j CONNMARK --restore-mark --mask 0x0f
 
-   ip rule del fwmark 0x1 lookup 100
-   ip route del local 0.0.0.0/0 dev lo table 100
+    ip rule del fwmark 0x1 lookup 100
+    ip route del local 0.0.0.0/0 dev lo table 100
 
 
-   ip6tables -t raw -D PREROUTING ! -i lo -d ::1/128 -j DROP & > /dev/null #silence ipv6 errors
-   ip6tables -t mangle -D POSTROUTING ! -o lo -s ::1/128 -j DROP & > /dev/null
-   ip6tables -t nat -D OUTPUT -m owner --uid-owner sslh -p tcp --tcp-flags FIN,SYN,RST,ACK SYN -j CONNMARK --set-xmark 0x01/0x0f & > /dev/null
-   ip6tables -t mangle -D OUTPUT ! -o lo -p tcp -m connmark --mark 0x01/0x0f -j CONNMARK --restore-mark --mask 0x0f & > /dev/null
+    if [ $(cat /proc/sys/net/ipv6/conf/all/disable_ipv6) -eq 0 ]; then
+        ip6tables -t raw -D PREROUTING ! -i lo -d ::1/128 -j DROP
+        ip6tables -t mangle -D POSTROUTING ! -o lo -s ::1/128 -j DROP
+        ip6tables -t nat -D OUTPUT -m owner --uid-owner sslh -p tcp --tcp-flags FIN,SYN,RST,ACK SYN -j CONNMARK --set-xmark 0x01/0x0f
+        ip6tables -t mangle -D OUTPUT ! -o lo -p tcp -m connmark --mark 0x01/0x0f -j CONNMARK --restore-mark --mask 0x0f
 
-   ip -6 rule del fwmark 0x1 lookup 100 & > /dev/null
-   ip -6 route del local ::/0 dev lo table 100 & > /dev/null
-   
-   set -e
+        ip -6 rule del fwmark 0x1 lookup 100
+        ip -6 route del local ::/0 dev lo table 100
+    fi
+        
+    set -e
+    set +x
 }
 
 configure_iptables() {
-   set +e # Don't exit if rule exist or ipv6 not enabled
+    echo "Configuring iptables and routing..."
 
-   echo "Configuring iptables and routing..."
+    set +e # Don't exit if got error
+    set -x
+    
+    iptables -t raw -A PREROUTING ! -i lo -d 127.0.0.0/8 -j DROP
+    iptables -t mangle -A POSTROUTING ! -o lo -s 127.0.0.0/8 -j DROP
 
-   iptables -t raw -A PREROUTING ! -i lo -d 127.0.0.0/8 -j DROP
-   iptables -t mangle -A POSTROUTING ! -o lo -s 127.0.0.0/8 -j DROP
+    iptables -t nat -A OUTPUT -m owner --uid-owner sslh -p tcp --tcp-flags FIN,SYN,RST,ACK SYN  -j CONNMARK --set-xmark 0x01/0x0f
+    iptables -t mangle -A OUTPUT ! -o lo -p tcp -m connmark --mark 0x01/0x0f -j CONNMARK --restore-mark --mask 0x0f
 
-   iptables -t nat -A OUTPUT -m owner --uid-owner sslh -p tcp --tcp-flags FIN,SYN,RST,ACK SYN -j CONNMARK --set-xmark 0x01/0x0f
-   iptables -t mangle -A OUTPUT ! -o lo -p tcp -m connmark --mark 0x01/0x0f -j CONNMARK --restore-mark --mask 0x0f
+    ip rule add fwmark 0x1 lookup 100
+    ip route add local 0.0.0.0/0 dev lo table 100
 
-   ip rule add fwmark 0x1 lookup 100
-   ip route add local 0.0.0.0/0 dev lo table 100
+    if [ $(cat /proc/sys/net/ipv6/conf/all/disable_ipv6) -eq 0 ]; then
+        ip6tables -t raw -A PREROUTING ! -i lo -d ::1/128 -j DROP
+        ip6tables -t mangle -A POSTROUTING ! -o lo -s ::1/128 -j DROP
+        ip6tables -t nat -A OUTPUT -m owner --uid-owner sslh -p tcp --tcp-flags FIN,SYN,RST,ACK SYN -j CONNMARK --set-xmark 0x01/0x0f
+        ip6tables -t mangle -A OUTPUT ! -o lo -p tcp -m connmark --mark 0x01/0x0f -j CONNMARK --restore-mark --mask 0x0f
 
-   ip6tables -t raw -A PREROUTING ! -i lo -d ::1/128 -j DROP & > /dev/null #silence ipv6 errors
-   ip6tables -t mangle -A POSTROUTING ! -o lo -s ::1/128 -j DROP & > /dev/null
-   ip6tables -t nat -A OUTPUT -m owner --uid-owner sslh -p tcp --tcp-flags FIN,SYN,RST,ACK SYN -j CONNMARK --set-xmark 0x01/0x0f & > /dev/null
-   ip6tables -t mangle -A OUTPUT ! -o lo -p tcp -m connmark --mark 0x01/0x0f -j CONNMARK --restore-mark --mask 0x0f & > /dev/null
-
-   ip -6 rule add fwmark 0x1 lookup 100 & > /dev/null
-   ip -6 route add local ::/0 dev lo table 100 & > /dev/null
-   
-   set -e
+        ip -6 rule add fwmark 0x1 lookup 100
+        ip -6 route add local ::/0 dev lo table 100
+    fi
+    
+    set -e
+    set +x
 }
 
 for i in "$@" ; do


### PR DESCRIPTION
Fix for #390.

Changes:
 - Add checking if ipv6 is enabled before implementing the ip6tables rules