### PR TITLE
fix handling of IPv6 UDP connections

### DIFF
--- a/common.h
+++ b/common.h
@@ -112,7 +112,7 @@ struct connection {
     struct queue q[2];
 
     /* SOCK_DGRAM */
-    struct sockaddr client_addr; /* Contains the remote client address */
+    struct sockaddr_storage client_addr; /* Contains the remote client address */
     socklen_t addrlen;
 
     int local_endpoint; /* Contains the local address */


### PR DESCRIPTION
Problem:
IPv6 addresses are 4 bytes long and don't fit inside a `sockaddr`, so `recvfrom` will truncate the address to the first half. When generating a reply, the remaining half of the address is filled with garbage and the packet is subsequently delivered to the wrong host, if not immediately dropped.

Solution:
replace `sockaddr` with `sockaddr_storage`, the latter is guaranteed to be large enough to hold an IPv6 address and pointers can be cast to `sockaddr *` when needed.