### PR TITLE
Cleanup error checking logic in bind_peer()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@
 *.o
 cscope.*
 echosrv
+libsslh.a
 sslh-fork
 sslh-select
+sslh-ev
 sslh.8.gz
 tags
 version.h


### PR DESCRIPTION
FWIW, last changes in `master` appear to work for me as well, so the only thing that keeps nagging me is the convoluted error checking logic.