### PR TITLE
Set image tag to use github in docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ version: "3"
 
 services:
   sslh:
-    image: sslh:latest
+    image: ghcr.io/yrutschle/sslh:latest
     hostname: sslh
     ports:
       - 443:443


### PR DESCRIPTION
Change image tag of the docker-compose example from ```sslh:latest``` to ```ghcr.io/yrutschle/sslh:latest```