### PR TITLE
Validate accept() return to prevent crash in start_shoveler

### DIFF
--- a/sslh-fork.c
+++ b/sslh-fork.c
@@ -178,6 +178,8 @@ void tcp_listener(struct listen_endpoint* endpoint, int num_endpoints, int activ
     while (1) {
         in_socket = accept(endpoint[active_endpoint].socketfd, 0, 0);
         CHECK_RES_RETURN(in_socket, "accept", /*void*/ );
+        if (in_socket < 0) continue;
+
         print_message(msg_fd, "accepted fd %d\n", in_socket);
 
         switch(fork()) {


### PR DESCRIPTION
The call to accept() in main_loop can fail in some cases, which results in an sslh crash in start_shoveler's call to FD_SET. To prevent this, let's avoid going into start_shoveler on an invalid in_socket.