### PR TITLE
Fix lint problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ sslh-ev
 sslh.8.gz
 tags
 version.h
+/config.status
+/config.log
+/config.h
+/Makefile

--- a/common.h
+++ b/common.h
@@ -172,7 +172,7 @@ int resolve_split_name(struct addrinfo **out, char* hostname, char* port);
 
 int start_listen_sockets(struct listen_endpoint *sockfd[]);
 
-int defer_write(struct queue *q, void* data, int data_size);
+int defer_write(struct queue *q, void* data, ssize_t data_size);
 int flush_deferred(struct queue *q);
 
 extern struct sslhcfg_item cfg;

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -7,6 +7,7 @@ available directly from [Github](https://github.com/yrutschle/sslh/pkgs/containe
 Windows binaries for Cygwin are graciously produced by
 nono303 on his [repository](https://github.com/nono303/sslh).
 
+
 Compile and install
 ===================
 
@@ -15,139 +16,130 @@ Dependencies
 
 `sslh` uses:
 
-* [libconfig](http://www.hyperrealm.com/libconfig/). For
-  Debian this is contained in package `libconfig-dev`. You
-can compile with or without it using USELIBCONFIG in the
-Makefile.
+* [libconfig](http://www.hyperrealm.com/libconfig/).
+  For Debian this is contained in package `libconfig-dev`.
+  You can compile with or without it using USELIBCONFIG in the Makefile.
 
 * [libwrap](http://packages.debian.org/source/unstable/tcp-wrappers).
-    For Debian, this is contained in packages
-`libwrap0-dev`. You
-can compile with or without it using USELIBWRAP in the
-Makefile.
+  For Debian, this is contained in packages `libwrap0-dev`.
+  You can compile with or without it using USELIBWRAP in the Makefile.
 
-* [libsystemd](http://packages.debian.org/source/unstable/libsystemd-dev), in package `libsystemd-dev`.  You
-can compile with or without it using USESYSTEMD in the
-Makefile.
+* [libsystemd](http://packages.debian.org/source/unstable/libsystemd-dev), in package `libsystemd-dev`.
+  You can compile with or without it using USESYSTEMD in the Makefile.
 
-* [libcap](http://packages.debian.org/source/unstable/libcap-dev), in package `libcap-dev`. You can compile with or without it using USELIBCAP in the Makefile
+* [libcap](http://packages.debian.org/source/unstable/libcap-dev), in package `libcap-dev`.
+  You can compile with or without it using USELIBCAP in the Makefile
 
-* libbsd, to enable to change the process name (as shown in
-  `ps`, so each forked process shows what protocol and what
-  connection it is serving),
-which requires `libbsd` at runtime, and `libbsd-dev` at
-compile-time.
+* libbsd, to enable to change the process name (as shown in `ps`,
+  so each forked process shows what protocol and what connection it is serving),
+  which requires `libbsd` at runtime, and `libbsd-dev` at compile-time.
 
-* libpcre2, in package `libpcre-dev`. You can compile
-  with or without it using ENABLE_REGEX in the Makefile.
+* libpcre2, in package `libpcre2-dev`.
+  You can compile with or without it using ENABLE_REGEX in the Makefile.
 
-* libev-dev, in package `libev-dev`. If you build a binary
-  specifically and do not build `sslh-ev`, you don't need
-  this.
+* libev-dev, in package `libev-dev`.
+  If you build a binary specifically and do not build `sslh-ev`, you don't need this.
 
 
 For OpenSUSE, these are contained in packages libconfig9 and
 libconfig-dev in repository
 <http://download.opensuse.org/repositories/multimedia:/libs/openSUSE_12.1/>
 
-For Fedora, you'll need packages `libconfig` and
-`libconfig-devel`:
+For Fedora, you'll need packages `libconfig` and `libconfig-devel`:
 
-	yum install libconfig libconfig-devel
+    yum install libconfig libconfig-devel
 
-If you want to rebuild `sslh-conf.c` (after a `make
-distclean` for example), you will also need to add
-[conf2struct](https://www.rutschle.net/tech/conf2struct/README.html)
+If you want to rebuild `sslh-conf.c` (after a `make distclean` for example),
+you will also need to add [conf2struct](https://www.rutschle.net/tech/conf2struct/README.html)
 (v1.5) to your path.
 
-
 The test scripts are written in Perl, and will require
-IO::Socket::INET6 (libio-socket-inet6-perl in Debian).
+`IO::Socket::INET6` (`libio-socket-inet6-perl` in Debian).
+
 
 Compilation
 -----------
 
 After this, the Makefile should work:
 
-	make install
+    make install
 
-There are a couple of configuration options at the beginning
-of the Makefile: 
+There are a couple of configuration options at the beginning of the Makefile: 
 
-* `USELIBWRAP` compiles support for host access control (see
-  `hosts_access(3)`), you will need `libwrap` headers and
-  library to compile (`libwrap0-dev` in Debian).
+* `USELIBWRAP` compiles support for host access control (see `hosts_access(3)`),
+  you will need `libwrap` headers and library to compile (`libwrap0-dev` in Debian).
 
-* `USELIBCONFIG` compiles support for the configuration
-  file. You will need `libconfig` headers to compile
-  (`libconfig8-dev` in Debian).
+* `USELIBCONFIG` compiles support for the configuration file.
+  You will need `libconfig` headers to compile (`libconfig8-dev` in Debian).
 
-*  `USESYSTEMD` compiles support for using systemd socket activation.
-   You will need `systemd` headers to compile (`systemd-devel` in Fedora).
+* `USESYSTEMD` compiles support for using systemd socket activation.
+  You will need `systemd` headers to compile (`systemd-devel` in Fedora).
 
-* `USELIBBSD` compiles support for updating the process name (as shown
-  by `ps`).
+* `USELIBBSD` compiles support for updating the process name (as shown by `ps`).
+
 
 Generating the configuration parser
 -----------------------------------
 
-The configuration file and command line parser is generated
-by `conf2struct`, from `sslhconf.cfg`, which generates
-`sslh-conf.c` and `sslh-conf.h`. The resulting files are
-included in the source so `sslh` can be built without
-`conf2struct` installed.
+The configuration file and command line parser is generated by `conf2struct`,
+from `sslhconf.cfg`, which generates `sslh-conf.c` and `sslh-conf.h`.
+The resulting files are included in the source
+so `sslh` can be built without `conf2struct` installed.
 
-Further, to prevent build issues, `sslh-conf.[ch]` has no
-dependency to `sslhconf.cfg` in the Makefile.  In the event
-of adding configuration settings, they need to be
-regenerated using `make c2s`.
+Further, to prevent build issues,
+`sslh-conf.[ch]` has no dependency to `sslhconf.cfg` in the Makefile.
+In the event of adding configuration settings,
+they need to be regenerated using `make c2s`.
+
 
 Binaries
 --------
 
-The Makefile produces three different executables: `sslh-fork`,
-`sslh-select` and `sslh-ev`:
+The Makefile produces three different executables:
+`sslh-fork`, `sslh-select` and `sslh-ev`:
 
 * `sslh-fork` forks a new process for each incoming connection.
-It is well-tested and very reliable, but incurs the overhead
-of many processes.  
-If you are going to use `sslh` for a "small" setup (less than
-a dozen ssh connections and a low-traffic https server) then
-`sslh-fork` is probably more suited for you. 
+  It is well-tested and very reliable, but incurs the overhead of many processes.  
+  If you are going to use `sslh` for a "small" setup
+  (less than a dozen ssh connections and a low-traffic https server)
+  then `sslh-fork` is probably more suited for you.
 
-* `sslh-select` uses only one thread, which monitors all
-  connections at once. It only incurs a 16 byte overhead per
-connection.  Also, if it stops, you'll lose all connections,
-which means you can't upgrade it remotely.  If you are going
-to use `sslh` on a "medium" setup (a few hundreds of
-connections), or if you are on a system where forking is
-expensive (e.g. Windows), `sslh-select` will be better.
+* `sslh-select` uses only one thread, which monitors all connections at once.
+  It only incurs a 16 byte overhead per connection.
+  Also, if it stops, you'll lose all connections,
+  which means you can't upgrade it remotely.
+  If you are going to use `sslh` on a "medium" setup (a few hundreds of connections),
+  or if you are on a system where forking is expensive (e.g. Windows),
+  `sslh-select` will be better.
 
-* `sslh-ev` is similar to `sslh-select`, but uses `libev` as
-  a backend. This allows using specific kernel APIs that
-allow to manage thousands of connections concurrently.
+* `sslh-ev` is similar to `sslh-select`, but uses `libev` as a backend.
+  This allows using specific kernel APIs that
+  allow to manage thousands of connections concurrently.
+
 
 Installation
 ------------
 
 * In general:
-
-		make
-		cp sslh-fork /usr/local/sbin/sslh
-		cp basic.cfg /etc/sslh.cfg
-                vi /etc/sslh.cfg
-
+  ```sh
+  ./configure
+  make
+  cp sslh-fork /usr/local/sbin/sslh
+  cp basic.cfg /etc/sslh.cfg
+  vi /etc/sslh.cfg
+  ```
 * For Debian:
-
-		cp scripts/etc.init.d.sslh /etc/init.d/sslh
-	
+  ```sh
+  cp scripts/etc.init.d.sslh /etc/init.d/sslh
+  ```
 * For CentOS:
-
-		cp scripts/etc.rc.d.init.d.sslh.centos /etc/rc.d/init.d/sslh
-
+  ```sh
+  cp scripts/etc.rc.d.init.d.sslh.centos /etc/rc.d/init.d/sslh
+  ```
 
 You might need to create links in /etc/rc<x>.d so that the server
 start automatically at boot-up, e.g. under Debian:
-
-	update-rc.d sslh defaults
+```sh
+update-rc.d sslh defaults
+```
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -4,7 +4,7 @@ Pre-built binaries
 Docker images of `master` and of the tagged versions are
 available directly from [Github](https://github.com/yrutschle/sslh/pkgs/container/sslh).
 
-Windows binaries for Cygwin are graciouly produced by
+Windows binaries for Cygwin are graciously produced by
 nono303 on his [repository](https://github.com/nono303/sslh).
 
 Compile and install

--- a/doc/README.Windows.md
+++ b/doc/README.Windows.md
@@ -7,7 +7,7 @@ should be avoided as it is very inefficient on Windows, but
 The following script downloads the latest cygwin, the latest version of sslh, and then compiles and copies the binaries with dependancies to an output folder.
 
 It may be needed to correct it from time to time, but it works. I use it in a virtual machine.
-Just retrieve WGET.EXE from [https://eternallybored.org/misc/wget/](url) or git binaries.
+Just retrieve WGET.EXE from https://eternallybored.org/misc/wget/ or git binaries.
 
 Copy the 3 files
 

--- a/echosrv.c
+++ b/echosrv.c
@@ -62,9 +62,10 @@ void check_res_dump(int res, struct addrinfo *addr, char* syscall)
 
 void start_echo(int fd)
 {
-    int res;
+    ssize_t res;
     char buffer[1 << 20];
-    int ret, prefix_len;
+    ssize_t ret;
+    size_t prefix_len;
     int first = 1;
 
     prefix_len = strlen(cfg.prefix);

--- a/echosrv.c
+++ b/echosrv.c
@@ -151,7 +151,7 @@ void udp_echo(struct listen_endpoint* listen_socket)
 
     while (1) {
         addrlen = sizeof(src_addr);
-        size_t len = recvfrom(listen_socket->socketfd, 
+        ssize_t len = recvfrom(listen_socket->socketfd,
                            data + prefix_len,
                            sizeof(data) - prefix_len,
                            0,
@@ -166,7 +166,7 @@ void udp_echo(struct listen_endpoint* listen_socket)
 
         print_udp_xchange(listen_socket->socketfd, &src_addr, addrlen);
 
-        int res = sendto(listen_socket->socketfd,
+        ssize_t res = sendto(listen_socket->socketfd,
                          data,
                          len + prefix_len,
                          0,

--- a/probe.c
+++ b/probe.c
@@ -323,7 +323,7 @@ static int is_adb_protocol(const char *p, ssize_t len, struct sslhcfg_protocols_
     if (len < min_data_packet_size + sizeof(empty_message))
         return PROBE_AGAIN;
 
-    if (memcmp(&p[0], empty_message, sizeof(empty_message)))
+    if (memcmp(&p[0], empty_message, sizeof(empty_message)) != 0)
         return PROBE_NEXT;
 
     return probe_adb_cnxn_message(&p[sizeof(empty_message)]);

--- a/sslh-main.c
+++ b/sslh-main.c
@@ -69,7 +69,7 @@ static void printsettings(void)
         strcpy(buf, "resolve on forward");
         if (!p->resolve_on_forward) {
             sprintaddr(buf, sizeof(buf), p->saddr);
-            int len = strlen(buf);
+            size_t len = strlen(buf);
             sprintf(buf+len, " family %d %d", 
                     p->saddr->ai_family,
                     p->saddr->ai_addr->sa_family);
@@ -98,7 +98,8 @@ static void printsettings(void)
 static void setup_regex_probe(struct sslhcfg_protocols_item *p)
 #ifdef ENABLE_REGEX
 {
-    int num_patterns, i, error;
+    size_t num_patterns, i;
+    int error;
     pcre2_code** pattern_list;
     PCRE2_SIZE error_offset;
     PCRE2_UCHAR8 err_str[120];
@@ -186,7 +187,7 @@ void config_sanity_check(struct sslhcfg_item* cfg)
 #endif
 
     for (i = 0; i < cfg->protocols_len; ++i) {
-        if (strcmp(cfg->protocols[i].name, "tls")) {
+        if (strcmp(cfg->protocols[i].name, "tls") != 0) {
             if (cfg->protocols[i].sni_hostnames_len) {
                 print_message(msg_config_error, "name: \"%s\"; host: \"%s\"; port: \"%s\": "
                               "Config option sni_hostnames is only applicable for tls\n",

--- a/tcp-probe.c
+++ b/tcp-probe.c
@@ -60,13 +60,13 @@ int probe_client_protocol(struct connection *cnx)
 
 static void tcp_protocol_list_init(void)
 {
+    tcp_protocols = calloc(cfg.protocols_len, sizeof(tcp_protocols));
+    CHECK_ALLOC(tcp_protocols, "tcp_protocols");
     for (int i = 0; i < cfg.protocols_len; i++) {
         struct sslhcfg_protocols_item* p = &cfg.protocols[i];
         if (!p->is_udp) {
+            tcp_protocols[tcp_protocols_len] = p;
             tcp_protocols_len++;
-            tcp_protocols = realloc(tcp_protocols, tcp_protocols_len * sizeof(*tcp_protocols));
-            CHECK_ALLOC(tcp_protocols, "realloc");
-            tcp_protocols[tcp_protocols_len-1] = p;
         }
     }
 }

--- a/tls.c
+++ b/tls.c
@@ -224,7 +224,7 @@ parse_server_name_extension(const struct TLSProtocol *tls_data, const char *data
         switch (data[pos]) { /* name type */
             case 0x00: /* host_name */
                 if(has_match(tls_data->sni_hostname_list, tls_data->sni_list_len, data + pos + 3, len)) {
-                    return len;
+                    return (int)len;
                 } else {
                     return TLS_ENOEXT;
                 }
@@ -253,7 +253,7 @@ parse_alpn_extension(const struct TLSProtocol *tls_data, const char *data, size_
             return TLS_EPROTOCOL;
 
         if (len > 0 && has_match(tls_data->alpn_protocol_list, tls_data->alpn_list_len, data + pos + 1, len)) {
-            return len;
+            return (int)len;
         } else if (len > 0) {
             print_message(msg_probe_error, "Unknown ALPN name: %.*s\n", (int)len, data + pos + 1);
         }
@@ -301,11 +301,11 @@ struct TLSProtocol *
 tls_data_set_list(struct TLSProtocol *tls_data, int alpn, const char** list, size_t list_len) {
     if (alpn) {
         tls_data->alpn_protocol_list = list;
-        tls_data->alpn_list_len = list_len;
+        tls_data->alpn_list_len = (int)list_len;
         tls_data->match_mode.tls_match_alpn = 1;
     } else {
         tls_data->sni_hostname_list = list;
-        tls_data->sni_list_len = list_len;
+        tls_data->sni_list_len = (int)list_len;
         tls_data->match_mode.tls_match_sni = 1;
     }
 

--- a/udp-listener.c
+++ b/udp-listener.c
@@ -259,7 +259,8 @@ struct connection* udp_c2s_forward(int sockfd, struct loop_info* fd_info)
     struct connection* cnx;
     ssize_t len;
     socklen_t addrlen;
-    int res, target, out = -1;
+    ssize_t res;
+    int target, out = -1;
     char data[65536]; /* Theoretical max is 65507 (https://en.wikipedia.org/wiki/User_Datagram_Protocol).
                          This will do.  Dynamic allocation is possible with the MSG_PEEK flag in recvfrom(2), but that'd imply
                          malloc/free overhead for each packet, when really 64K is not that much */
@@ -280,7 +281,7 @@ struct connection* udp_c2s_forward(int sockfd, struct loop_info* fd_info)
                   len, target, sprintaddr(addr_str, sizeof(addr_str), &addrinfo));
 
     if (target == -1) {
-        res = probe_buffer(data, len, udp_protocols, udp_protocols_len, &proto);
+        res = probe_buffer(data, (int)len, udp_protocols, udp_protocols_len, &proto);
         /* First version: if we can't work out the protocol from the first
          * packet, drop it. Conceivably, we could store several packets to
          * run probes on packet sets */
@@ -324,7 +325,7 @@ void udp_s2c_forward(struct connection* cnx)
 {
     int sockfd = cnx->target_sock;
     char data[65536];
-    int res;
+    ssize_t res;
 
     res = recvfrom(sockfd, data, sizeof(data), 0, NULL, NULL);
     if ((res == -1) && ((errno == EAGAIN) || (errno == EWOULDBLOCK))) return;


### PR DESCRIPTION
The CLion IDE has built-in CLang-Tidy linter and it marked a lot of warnings.
I checked and they all looks safe but just to at least reduce the visual noise here I fied some of them.

The last commit is an optimization and simplification.
You are using `realloc` in many places but the function is often allocates a new chunk of memorh and copy from old. So it may work longer.
Instead we can pre-allocate the array but fill with only needed elements.
So we have one alloc instead of N.
We may use slightly more memory but that's fine.

https://stackoverflow.com/questions/6727136/performance-impact-of-realloc
