### PR TITLE
Fix allocation size for interface name to include null-byte

### DIFF
--- a/systemd-sslh-generator.c
+++ b/systemd-sslh-generator.c
@@ -88,7 +88,7 @@ static int get_listen_from_conf(const char *filename, char **listen[]) {
                 } else {
                     char *resolved_listen = resolve_listen(hostname, port);
 
-                    (*listen)[i] = malloc(strlen(resolved_listen));
+                    (*listen)[i] = malloc(strlen(resolved_listen) + 1);
                     CHECK_ALLOC((*listen)[i], "malloc");
                     strcpy((*listen)[i], resolved_listen);
                     free(resolved_listen);


### PR DESCRIPTION
Related to recent _FORTIFY_SOURCE=3 changes in Arch Linux:

https://gitlab.archlinux.org/archlinux/packaging/packages/sslh/-/issues/2