### PR TITLE
echosrv.c: fix format '%ld' expects argument of type 'long int', but was ssize_t

### DIFF
--- a/echosrv.c
+++ b/echosrv.c
@@ -163,7 +163,7 @@ void udp_echo(struct listen_endpoint* listen_socket)
             perror("recvfrom");
         }
         *(data + prefix_len + len) = 0;
-        fprintf(stderr, "%ld: %s\n", len, data + prefix_len);
+        fprintf(stderr, "%zd %s\n", len, data + prefix_len);
 
         print_udp_xchange(listen_socket->socketfd, &src_addr, addrlen);
 


### PR DESCRIPTION
When building the sshl package for OpenWrt for the 32bit x86 the compiler shows:
```
echosrv.c: In function 'udp_echo':
echosrv.c:166:28: warning: format '%ld' expects argument of type 'long int', but argument 3 has type 'ssize_t' {aka 'int'} [-Wformat=]
  166 |         fprintf(stderr, "%ld: %s\n", len, data + prefix_len);
      |                          ~~^         ~~~
      |                            |         |
      |                            long int  ssize_t {aka int}
      |                          %d
```


So I replaced the `%ld` with `%zd` and this fixed the warning
 https://stackoverflow.com/questions/174612/cross-platform-format-string-for-variables-of-type-size-t

But I didn't tested that specific place but hope everything should be fine