### PR TITLE
Include version.h in repository, remove from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ sslh-ev
 systemd-sslh-generator
 sslh.8.gz
 tags
-version.h
 /config.status
 /config.log
 /config.h

--- a/Makefile.in
+++ b/Makefile.in
@@ -86,8 +86,9 @@ all: sslh-fork sslh-select $(MAN) echosrv $(CONDITIONAL_TARGETS)
 $(OBJS_A): $(OBJS)
 	$(AR) rcs $(OBJS_A) $(OBJS)
 
-version.h:
+version.h: .FORCE
 	./genver.sh >version.h
+.FORCE:	
 
 $(OBJS) $(FORK_OBJS) $(SELECT_OBJS) $(EV_OBJS): argtable3.h collection.h common.h gap.h hash.h log.h probe.h processes.h sslh-conf.h tcp-listener.h tcp-probe.h tls.h udp-listener.h version.h
 
@@ -160,6 +161,7 @@ distclean: clean
 
 clean:
 	rm -f sslh-fork sslh-select $(CONDITIONAL_TARGETS) echosrv version.h $(MAN) systemd-sslh-generator *.o *.gcov *.gcno *.gcda *.png *.html *.css *.info
+	echo "// this is a placeholder for version.h, to make code-checking editors happy" > version.h
 
 tags:
 	ctags --globals -T *.[ch]

--- a/version.h
+++ b/version.h
@@ -1,0 +1,1 @@
+// this is a placeholder for version.h, to make code-checking editors happy


### PR DESCRIPTION
Many code checking editors, marking the common.h as erroneous, as version.h is missing. 
This can lead to confusion. Change in Makefile.in
- with fake empty dependency ensures, that version.h is recreated at every "make"
- another change, makes sure, that `make clean`  generates  a stub of version.h with no content

version.h removed from .gitignore

With this change the code will look pretty and without any error, after fresh clone and after each `make clean`.
It was really driving my nuts, why my editor marked the code sometimes as buggy and sometimes not.