### PR TITLE
Fix possible file descriptor leak

### DIFF
--- a/common.c
+++ b/common.c
@@ -963,6 +963,7 @@ void write_pid_file(const char* pidfile)
     res = fprintf(f, "%d\n", getpid());
     if (res < 0) {
         print_message(msg_system_error, "write_pid_file: fprintf: %s\n", strerror(errno));
+        fclose(f);
         return;
     }
 


### PR DESCRIPTION
If ```fprintf``` fails, a file descriptor leak occurs.
So, I added ```fclose(f)```.