### PR TITLE
common.h: add a declaration of hosts_ctl for macOS

### DIFF
--- a/common.h
+++ b/common.h
@@ -34,6 +34,10 @@
 #include <sys/capability.h>
 #endif
 
+#ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#endif
+
 #include "config.h"
 #include "version.h"
 
@@ -181,6 +185,10 @@ int flush_deferred(struct queue *q);
 extern struct sslhcfg_item cfg;
 extern struct addrinfo *addr_listen;
 extern const char* server_type;
+
+#if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED < 1080)
+extern int hosts_ctl();
+#endif
 
 /* sslh-fork.c */
 void start_shoveler(int);


### PR DESCRIPTION
Fixes: https://github.com/yrutschle/sslh/issues/492

While I did not find a declaration on newer macOS versions either, the error happens only on < 10.8. On 10.7 buildbot it is a warning, because clang is less strict: https://build.macports.org/builders/ports-10.7_x86_64-builder/builds/219880/steps/install-port/logs/stdio

Possibly in later macOS the symbol was just removed. At least on 10.8 it is not found during configure: 
```
checking for hosts_ctl in -lwrap... no
```
https://build.macports.org/builders/ports-10.8_x86_64-builder/builds/205300/steps/install-port/logs/stdio

So I restrict this to < 10.8.