### PR TITLE
Fix mistype in accept(2) error handling

### DIFF
--- a/sslh-fork.c
+++ b/sslh-fork.c
@@ -182,9 +182,9 @@ void tcp_listener(struct listen_endpoint* endpoint, int num_endpoints, int activ
     while (1) {
         in_socket = accept(endpoint[active_endpoint].socketfd, 0, 0);
         if (in_socket == -1) {
-            print_message(msg_system_error, "%s:%d:%s:%d:%s\n", 
+            print_message(msg_system_error, "%s:%d:%s:%d:%s\n",
                           __FILE__, __LINE__, "accept", errno, strerror(errno));
-            switch(in_socket) {
+            switch(errno) {
             case ENETDOWN:  /* accept(2) cites all these errnos as "you should retry" */
             case EPROTO:
             case ENOPROTOOPT:


### PR DESCRIPTION
Due to a mistype in errno checking, sslh-fork process died repeatedly resulting to a complete denial of service on systems with no built-in process supervisors, like FreeBSD.