### PR TITLE
Add missing trailing "\n" to log output

### DIFF
--- a/common.c
+++ b/common.c
@@ -899,7 +899,7 @@ int check_access_rights(int in_socket, const char* service)
     }
 
     if (!hosts_ctl((char*)service, host, addr_str, STRING_UNKNOWN)) {
-        print_message(msg_connections, "connection from %s(%s): access denied", host, addr_str);
+        print_message(msg_connections, "connection from %s(%s): access denied\n", host, addr_str);
         close(in_socket);
         return -1;
     }


### PR DESCRIPTION
Just found a missing trailing "\n" in logging code.

p.s.
Thank you for publishing sslh.
sslh helps me very much. I appreciate your work.