### PR TITLE
Improve configure.ac to work with newer autoconf versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,12 +7,17 @@ AC_INIT
 AC_CONFIG_HEADERS(config.h)
 AC_CONFIG_FILES([Makefile])
 
-AC_CHECK_LIB([wrap], [hosts_ctl], [AC_DEFINE(HAVE_LIBWRAP) LIBS="$LIBS -lwrap" ], [])
-AC_CHECK_LIB([cap], [cap_get_proc], [AC_DEFINE(HAVE_LIBCAP) LIBS="$LIBS -lcap" ], [])
-AC_CHECK_LIB([bsd], [setproctitle], [AC_DEFINE(HAVE_LIBBSD) LIBS="$LIBS -lbsd" ], [])
+AC_CHECK_LIB([wrap], [hosts_ctl],
+  [AC_DEFINE([HAVE_LIBWRAP], [1], [Libwrap, to support host_ctl, /etc/allow and /etc/deny]) LIBS="$LIBS -lwrap"])
+AC_CHECK_LIB([cap], [cap_get_proc],
+  [AC_DEFINE([HAVE_LIBCAP], [1], [libcap support, to use Linux capabilities]) LIBS="$LIBS -lcap"])
+AC_CHECK_LIB([bsd], [setproctitle],
+  [AC_DEFINE([HAVE_LIBBSD], [1], [libbsd, to change process name]) LIBS="$LIBS -lbsd"])
 
-AC_CHECK_HEADERS(linux/landlock.h, AC_DEFINE(HAVE_LANDLOCK), [])
-AC_CHECK_HEADERS(proxy_protocol.h, [AC_DEFINE(HAVE_PROXYPROTOCOL) LIBS="$LIBS -lproxyprotocol" ], [])
+AC_CHECK_HEADERS(linux/landlock.h,
+  AC_DEFINE([HAVE_LANDLOCK], [1], [Landlock sandboxing Linux LSM]))
+AC_CHECK_HEADERS(proxy_protocol.h,
+  [AC_DEFINE([HAVE_PROXYPROTOCOL], [1], [Support for Proxy-protocol using libproxyprotocol]) LIBS="$LIBS -lproxyprotocol"])
 
 LIBS="$LIBS"
 AC_SUBST([LIBS])


### PR DESCRIPTION
When I tried to build a local debian package for sslh-v2.3.1 it failed because the `autoreconf -f -i -v` failed.
This PR fixes the autoreconf with version 2.72 of autoconf.

There were other issues for building the debian package for sslh-v2.3.1, but those are not addressed in this PR.
