### PR TITLE
udp_c2s_forward: silently ignore EAGAIN/EWOULDBLOCK on recvfrom

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,16 @@
 vNEXT:
+	udp_c2s_forward() now silently ignores EAGAIN /
+	EWOULDBLOCK from recvfrom() on the listening UDP
+	socket, matching udp_s2c_forward(). On Linux, a
+	non-blocking UDP socket flagged readable by
+	select() can still return EAGAIN at recv time when
+	the packet has a bad UDP checksum or is otherwise
+	dropped between select and recv. Public UDP
+	listeners (e.g. WireGuard-over-:443 sharing the
+	port with QUIC traffic) previously logged one
+	"recvfrom: Resource temporarily unavailable" line
+	per such packet.
+
 	verbose_packet now also dumps UDP packets.
 
 v2.3.1:

--- a/udp-listener.c
+++ b/udp-listener.c
@@ -274,6 +274,13 @@ struct connection* udp_c2s_forward(int sockfd, struct loop_info* fd_info)
     addrlen = sizeof(src_addr);
     len = recvfrom(sockfd, data, sizeof(data), 0, (struct sockaddr*) &src_addr, &addrlen);
     if (len < 0) {
+        /* On Linux, recvfrom() on a non-blocking UDP socket can legitimately
+         * return EAGAIN/EWOULDBLOCK after select() reported the socket as
+         * readable: a packet with a bad UDP checksum is dropped at recv time,
+         * not at queue time, and similar races exist with SO_REUSEPORT and
+         * socket filters. Treat that as a no-op rather than spamming stderr,
+         * mirroring what udp_s2c_forward() already does. */
+        if (errno == EAGAIN || errno == EWOULDBLOCK) return NULL;
         perror("recvfrom");
         return NULL;
     }


### PR DESCRIPTION
Hello, I've set up SSLH to multiplex between HTTPS and WireGuard on port 443. WireGuard uses UDP, and UDP on port 443 is QUIC, and there's a lot of log noise because of ambient scanning on the open internet. So I've investigated with Opus 4.7 and it came up with this patch and the following commit message:

> A non-blocking UDP listening socket flagged readable by select() can still legitimately return -1 with errno EAGAIN/EWOULDBLOCK from recvfrom(2): on Linux the UDP checksum is validated at recv time, so a packet with a bad checksum is silently dropped and the next recvfrom returns EAGAIN. Similar races exist with SO_REUSEPORT siblings, socket filters, and conntrack drops.
> 
> udp_s2c_forward() already special-cases this and returns silently. In udp_c2s_forward() the same condition fell through to perror("recvfrom"), which writes to stderr unconditionally (it does not go through print_message() / verbosity gating). On a public-internet UDP listener on a port that also receives unrelated traffic (e.g. WireGuard sharing :443/UDP with QUIC probes from web browsers), this produces a steady stream of 'recvfrom: Resource temporarily unavailable' lines in the journal with no functional impact.
> 
> Mirror the udp_s2c_forward() pattern: return NULL silently on EAGAIN/EWOULDBLOCK, keep perror() for genuinely unexpected errors.

Thanks for sslh, cool project! It helps me bypass outgoing port restrictions in a complicated network setup I have to deal with.