### PR TITLE
fix: close err_log after writing success message in main()

### DIFF
--- a/systemd-sslh-generator.c
+++ b/systemd-sslh-generator.c
@@ -307,11 +307,11 @@ int main(int argc, char *argv[]) {
             err_log = stderr;
         }
         const int r = gen_sslh_config(systemd_invoked ? argv[1] : "");
-        if (systemd_invoked) {
-            fclose(err_log);
-        }
         if (!r) {
             fprintf(err_log, "systemd-sslh-generator: Successfully generated all targets.\n");
+        }
+        if (systemd_invoked) {
+            fclose(err_log);
         }
         return r < 0 ? -1 : 0;
     } else {


### PR DESCRIPTION
err_log was fclose()'d before the "Successfully generated all targets" fprintf(), resulting in a write-after-close that corrupted glibc's internal stdio buffers and triggered an abort() via SIGABRT on every systemd-invoked run regardless of whether /etc/sslh/ exists.

Fix by moving the success fprintf() above the fclose() call.